### PR TITLE
Add support for ERC-721 (NFT) Tokens

### DIFF
--- a/src/main/java/io/api/etherscan/core/IAccountApi.java
+++ b/src/main/java/io/api/etherscan/core/IAccountApi.java
@@ -93,7 +93,7 @@ public interface IAccountApi {
     List<TxInternal> txsInternalByHash(String txhash) throws ApiException;
 
     /**
-     * All token txs for given address
+     * All ERC-20 token txs for given address
      * 
      * @param address    get txs for
      * @param startBlock tx from this blockNumber
@@ -109,6 +109,24 @@ public interface IAccountApi {
 
     @NotNull
     List<TxToken> txsToken(String address) throws ApiException;
+
+    /**
+     * All ERC-721 (NFT) token txs for given address
+     *
+     * @param address    get txs for
+     * @param startBlock tx from this blockNumber
+     * @param endBlock   tx to this blockNumber
+     * @return txs for address
+     * @throws ApiException parent exception class
+     */
+    @NotNull
+    List<TxToken> txsNftToken(String address, long startBlock, long endBlock) throws ApiException;
+
+    @NotNull
+    List<TxToken> txsNftToken(String address, long startBlock) throws ApiException;
+
+    @NotNull
+    List<TxToken> txsNftToken(String address) throws ApiException;
 
     /**
      * All blocks mined by address

--- a/src/main/java/io/api/etherscan/core/impl/AccountApiProvider.java
+++ b/src/main/java/io/api/etherscan/core/impl/AccountApiProvider.java
@@ -34,6 +34,7 @@ public class AccountApiProvider extends BasicProvider implements IAccountApi {
     private static final String ACT_TX_ACTION = ACT_PREFIX + "txlist";
     private static final String ACT_TX_INTERNAL_ACTION = ACT_PREFIX + "txlistinternal";
     private static final String ACT_TX_TOKEN_ACTION = ACT_PREFIX + "tokentx";
+    private static final String ACT_TX_NFT_TOKEN_ACTION = ACT_PREFIX + "tokennfttx";
     private static final String ACT_MINED_ACTION = ACT_PREFIX + "getminedblocks";
 
     private static final String BLOCK_TYPE_PARAM = "&blocktype=blocks";
@@ -225,6 +226,29 @@ public class AccountApiProvider extends BasicProvider implements IAccountApi {
         final String offsetParam = PAGE_PARAM + "%s" + OFFSET_PARAM + OFFSET_MAX;
         final String blockParam = START_BLOCK_PARAM + blocks.start() + END_BLOCK_PARAM + blocks.end();
         final String urlParams = ACT_TX_TOKEN_ACTION + offsetParam + ADDRESS_PARAM + address + blockParam + SORT_ASC_PARAM;
+
+        return getRequestUsingOffset(urlParams, TxTokenResponseTO.class);
+    }
+
+
+    @Override
+    public @NotNull List<TxToken> txsNftToken(String address) throws ApiException {
+        return txsNftToken(address, MIN_START_BLOCK);
+    }
+
+    @Override
+    public @NotNull List<TxToken> txsNftToken(String address, long startBlock) throws ApiException {
+        return txsNftToken(address, startBlock, MAX_END_BLOCK);
+    }
+
+    @Override
+    public @NotNull List<TxToken> txsNftToken(String address, long startBlock, long endBlock) throws ApiException {
+        BasicUtils.validateAddress(address);
+        final BlockParam blocks = BasicUtils.compensateBlocks(startBlock, endBlock);
+
+        final String offsetParam = PAGE_PARAM + "%s" + OFFSET_PARAM + OFFSET_MAX;
+        final String blockParam = START_BLOCK_PARAM + blocks.start() + END_BLOCK_PARAM + blocks.end();
+        final String urlParams = ACT_TX_NFT_TOKEN_ACTION + offsetParam + ADDRESS_PARAM + address + blockParam + SORT_ASC_PARAM;
 
         return getRequestUsingOffset(urlParams, TxTokenResponseTO.class);
     }

--- a/src/main/java/io/api/etherscan/core/impl/AccountApiProvider.java
+++ b/src/main/java/io/api/etherscan/core/impl/AccountApiProvider.java
@@ -230,19 +230,21 @@ public class AccountApiProvider extends BasicProvider implements IAccountApi {
         return getRequestUsingOffset(urlParams, TxTokenResponseTO.class);
     }
 
-
+    @NotNull
     @Override
-    public @NotNull List<TxToken> txsNftToken(String address) throws ApiException {
+    public List<TxToken> txsNftToken(String address) throws ApiException {
         return txsNftToken(address, MIN_START_BLOCK);
     }
 
+    @NotNull
     @Override
-    public @NotNull List<TxToken> txsNftToken(String address, long startBlock) throws ApiException {
+    public List<TxToken> txsNftToken(String address, long startBlock) throws ApiException {
         return txsNftToken(address, startBlock, MAX_END_BLOCK);
     }
 
+    @NotNull
     @Override
-    public @NotNull List<TxToken> txsNftToken(String address, long startBlock, long endBlock) throws ApiException {
+    public  List<TxToken> txsNftToken(String address, long startBlock, long endBlock) throws ApiException {
         BasicUtils.validateAddress(address);
         final BlockParam blocks = BasicUtils.compensateBlocks(startBlock, endBlock);
 

--- a/src/main/java/io/api/etherscan/core/impl/AccountApiProvider.java
+++ b/src/main/java/io/api/etherscan/core/impl/AccountApiProvider.java
@@ -244,7 +244,7 @@ public class AccountApiProvider extends BasicProvider implements IAccountApi {
 
     @NotNull
     @Override
-    public  List<TxToken> txsNftToken(String address, long startBlock, long endBlock) throws ApiException {
+    public List<TxToken> txsNftToken(String address, long startBlock, long endBlock) throws ApiException {
         BasicUtils.validateAddress(address);
         final BlockParam blocks = BasicUtils.compensateBlocks(startBlock, endBlock);
 

--- a/src/test/java/io/api/etherscan/account/AccountTxRc721TokenTest.java
+++ b/src/test/java/io/api/etherscan/account/AccountTxRc721TokenTest.java
@@ -1,0 +1,80 @@
+package io.api.etherscan.account;
+
+import io.api.ApiRunner;
+import io.api.etherscan.error.InvalidAddressException;
+import io.api.etherscan.model.TxToken;
+import org.junit.Test;
+
+import java.util.List;
+
+/**
+ * @author NGuggs
+ * @since 11.28.2021
+ */
+public class AccountTxRc721TokenTest extends ApiRunner {
+
+    @Test
+    public void correct() {
+        List<TxToken> txs = getApi().account().txsNftToken("0x1a1ebe0d86f72884c3fd484ae1e796e08f8ffa67");
+        assertNotNull(txs);
+        assertEquals(16, txs.size());
+        assertTxs(txs);
+        assertNotEquals(0, txs.get(0).getGasPrice());
+        assertNotEquals(-1, txs.get(0).getNonce());
+
+        assertNotNull(txs.get(0).toString());
+        assertNotEquals(txs.get(0).toString(), txs.get(1).toString());
+
+        assertNotEquals(txs.get(0), txs.get(1));
+        assertNotEquals(txs.get(0).hashCode(), txs.get(1).hashCode());
+
+        assertEquals(txs.get(1), txs.get(1));
+        assertEquals(txs.get(1).hashCode(), txs.get(1).hashCode());
+    }
+
+    @Test
+    public void correctStartBlock() {
+        List<TxToken> txs = getApi().account().txsNftToken("0x1a1ebe0d86f72884c3fd484ae1e796e08f8ffa67", 4762071);
+        System.out.println(txs);
+        assertNotNull(txs);
+        assertEquals(5, txs.size());
+        assertTxs(txs);
+    }
+
+    @Test
+    public void correctStartBlockEndBlock() {
+        List<TxToken> txs = getApi().account().txsNftToken("0x1a1ebe0d86f72884c3fd484ae1e796e08f8ffa67", 4761862, 4761934);
+        System.out.println(txs);
+        assertNotNull(txs);
+        assertEquals(11, txs.size());
+        assertTxs(txs);
+    }
+
+    @Test(expected = InvalidAddressException.class)
+    public void invalidParamWithError() {
+        getApi().account().txsNftToken("0x6ec53A8fBa6358d59B3C4476D82cc60A2B0FaD7");
+    }
+
+    @Test
+    public void correctParamWithEmptyExpectedResult() {
+        List<TxToken> txs = getApi().account().txsNftToken("0x31ec53A8fBa6358d59B3C4476D82cc60A2B0FaD7");
+        assertNotNull(txs);
+        assertTrue(txs.isEmpty());
+    }
+
+    private void assertTxs(List<TxToken> txs) {
+        for (TxToken tx : txs) {
+            assertNotNull(tx.getBlockHash());
+            assertNotNull(tx.getTokenName());
+            assertNotNull(tx.getTokenSymbol());
+            assertNotNull(tx.getFrom());
+            assertNotNull(tx.getTo());
+            assertNotNull(tx.getTimeStamp());
+            assertNotNull(tx.getTokenDecimal());
+            assertNotEquals(-1, (tx.getConfirmations()));
+            assertNotNull(tx.getGasUsed());
+            assertNotEquals(-1, tx.getCumulativeGasUsed());
+            assertNotEquals(-1, tx.getTransactionIndex());
+        }
+    }
+}


### PR DESCRIPTION
I noticed there was currently only support for ERC-20 tokens and that Ertherscan used a different endpoint to get ERC-721 (NFT) Tokens. 

## Changes
I followed the same paradigm used for the ERC-20 tokens and just duplicated and changed for the new endpoint. 

## Considerations
With how similar the tokens are in requests, the methods could be combined into a single set with an enum or parameter (or similar in function) that determines which token type your are intending and reduces nearly duplicate code. Though it would take extra work to support backwards compatible upgrades to the new version. 

## Testing
Manually tested against a random account (_0x51b1501420C50aDdA1C4942720bC0e7e8C6D768e_) which includes both ERC-20 and ERC-721 tokens. 

Still need to add test cases for this. But... was curious how you chose the account for the initial set of test cases. I noticed that account did not have ERC-721 tokens and I would be hesitant to use a random account knowing there could be additional tokens in the future and break the tests.

Let me know your throughts.

