### PR TITLE
Changed traceId in TxInternal from long to String

### DIFF
--- a/src/main/java/io/api/etherscan/model/TxInternal.java
+++ b/src/main/java/io/api/etherscan/model/TxInternal.java
@@ -11,7 +11,7 @@ import java.util.Objects;
 public class TxInternal extends BaseTx {
 
     private String type;
-    private long traceId;
+    private String traceId;
     private int isError;
     private String errCode;
 
@@ -20,7 +20,7 @@ public class TxInternal extends BaseTx {
         return type;
     }
 
-    public long getTraceId() {
+    public String getTraceId() {
         return traceId;
     }
 
@@ -44,7 +44,7 @@ public class TxInternal extends BaseTx {
 
         TxInternal that = (TxInternal) o;
 
-        if (traceId != that.traceId)
+        if (!Objects.equals(traceId, that.traceId))
             return false;
         return Objects.equals(errCode, that.errCode);
     }
@@ -52,7 +52,7 @@ public class TxInternal extends BaseTx {
     @Override
     public int hashCode() {
         int result = super.hashCode();
-        result = 31 * result + (int) (traceId ^ (traceId >>> 32));
+        result = 31 * result + (traceId != null ? traceId.hashCode() : 0);
         result = 31 * result + (errCode != null ? errCode.hashCode() : 0);
         return result;
     }


### PR DESCRIPTION
Great Java implementation for the etherscan api! While fetching internal transaction data, I ran into a ParseException because of the traceId value of "1_0". In my case it was a refund from a uniswap trade.

You can check it yourself with address 0x82c1174618133b1a320106aa197d0e8ee7e36be4 (random address that interacted with uniswap and has non numeric traceIds for some of its internal transactions.