### PR TITLE
Add support for PolygonScan

### DIFF
--- a/src/main/java/io/api/etherscan/core/IAccountApi.java
+++ b/src/main/java/io/api/etherscan/core/IAccountApi.java
@@ -137,4 +137,59 @@ public interface IAccountApi {
      */
     @NotNull
     List<Block> minedBlocks(String address) throws ApiException;
+
+    @NotNull
+    List<TxErc20> erc20Transfers(String address) throws ApiException;
+
+    @NotNull
+    List<TxErc20> erc20Transfers(String address, long startBlock) throws ApiException;
+
+    /**
+     * All ERC-20 token txs for given address
+     *
+     * @param address    get txs for
+     * @param startBlock tx from this blockNumber
+     * @param endBlock   tx to this blockNumber
+     * @return txs for address
+     * @throws ApiException parent exception class
+     */
+    @NotNull
+    List<TxErc20> erc20Transfers(String address, long startBlock, long endBlock) throws ApiException;
+
+    @NotNull
+    List<TxErc721> erc721Transfers(String address) throws ApiException;
+
+    @NotNull
+    List<TxErc721> erc721Transfers(String address, long startBlock) throws ApiException;
+
+    /**
+     * All ERC-721 (NFT) token txs for given address
+     *
+     * @param address    get txs for
+     * @param startBlock tx from this blockNumber
+     * @param endBlock   tx to this blockNumber
+     * @return txs for address
+     * @throws ApiException parent exception class
+     */
+    @NotNull
+    List<TxErc721> erc721Transfers(String address, long startBlock, long endBlock) throws ApiException;
+
+    @NotNull
+    List<TxErc1155> erc1155Transfers(String address) throws ApiException;
+
+    @NotNull
+    List<TxErc1155> erc1155Transfers(String address, long startBlock) throws ApiException;
+
+    /**
+     * All ERC-1155 token txs for given address
+     *
+     * @param address    get txs for
+     * @param startBlock tx from this blockNumber
+     * @param endBlock   tx to this blockNumber
+     * @return txs for address
+     * @throws ApiException parent exception class
+     */
+    @NotNull
+    List<TxErc1155> erc1155Transfers(String address, long startBlock, long endBlock) throws ApiException;
+
 }

--- a/src/main/java/io/api/etherscan/core/impl/AccountApiProvider.java
+++ b/src/main/java/io/api/etherscan/core/impl/AccountApiProvider.java
@@ -35,6 +35,7 @@ public class AccountApiProvider extends BasicProvider implements IAccountApi {
     private static final String ACT_TX_INTERNAL_ACTION = ACT_PREFIX + "txlistinternal";
     private static final String ACT_TX_TOKEN_ACTION = ACT_PREFIX + "tokentx";
     private static final String ACT_TX_NFT_TOKEN_ACTION = ACT_PREFIX + "tokennfttx";
+    private static final String ACT_TX_1155_TOKEN_ACTION = ACT_PREFIX + "token1155tx";
     private static final String ACT_MINED_ACTION = ACT_PREFIX + "getminedblocks";
 
     private static final String BLOCK_TYPE_PARAM = "&blocktype=blocks";
@@ -264,5 +265,71 @@ public class AccountApiProvider extends BasicProvider implements IAccountApi {
         final String urlParams = ACT_MINED_ACTION + offsetParam + BLOCK_TYPE_PARAM + ADDRESS_PARAM + address;
 
         return getRequestUsingOffset(urlParams, BlockResponseTO.class);
+    }
+
+    @NotNull
+    @Override
+    public List<TxErc20> erc20Transfers(String address) throws ApiException {
+        return erc20Transfers(address, MIN_START_BLOCK);
+    }
+
+    @NotNull
+    @Override
+    public List<TxErc20> erc20Transfers(String address, long startBlock) throws ApiException {
+        return erc20Transfers(address, startBlock, MAX_END_BLOCK);
+    }
+
+    @NotNull
+    @Override
+    public List<TxErc20> erc20Transfers(String address, long startBlock, long endBlock) throws ApiException {
+        return getTokenTransfers(address, startBlock, endBlock, ACT_TX_TOKEN_ACTION, TxErc20ResponseTO.class);
+    }
+
+    @NotNull
+    @Override
+    public List<TxErc721> erc721Transfers(String address) throws ApiException {
+        return erc721Transfers(address, MIN_START_BLOCK);
+    }
+
+    @NotNull
+    @Override
+    public List<TxErc721> erc721Transfers(String address, long startBlock) throws ApiException {
+        return erc721Transfers(address, startBlock, MAX_END_BLOCK);
+    }
+
+    @NotNull
+    @Override
+    public List<TxErc721> erc721Transfers(String address, long startBlock, long endBlock) throws ApiException {
+        return getTokenTransfers(address, startBlock, endBlock, ACT_TX_NFT_TOKEN_ACTION, TxErc721ResponseTO.class);
+    }
+
+    @NotNull
+    @Override
+    public List<TxErc1155> erc1155Transfers(String address) throws ApiException {
+        return erc1155Transfers(address, MIN_START_BLOCK);
+    }
+
+    @NotNull
+    @Override
+    public List<TxErc1155> erc1155Transfers(String address, long startBlock) throws ApiException {
+        return erc1155Transfers(address, startBlock, MAX_END_BLOCK);
+    }
+
+    @NotNull
+    @Override
+    public List<TxErc1155> erc1155Transfers(String address, long startBlock, long endBlock) throws ApiException {
+        return getTokenTransfers(address, startBlock, endBlock, ACT_TX_1155_TOKEN_ACTION, TxErc1155ResponseTO.class);
+    }
+
+    @NotNull
+    private <T extends BaseTxToken, R extends BaseListResponseTO<T>> List<T> getTokenTransfers(String address, long startBlock, long endBlock, String tokenAction, Class<R> responseTOClass) throws ApiException {
+        BasicUtils.validateAddress(address);
+        final BlockParam blocks = BasicUtils.compensateBlocks(startBlock, endBlock);
+
+        final String offsetParam = PAGE_PARAM + "%s" + OFFSET_PARAM + OFFSET_MAX;
+        final String blockParam = START_BLOCK_PARAM + blocks.start() + END_BLOCK_PARAM + blocks.end();
+        final String urlParams = tokenAction + offsetParam + ADDRESS_PARAM + address + blockParam + SORT_ASC_PARAM;
+
+        return getRequestUsingOffset(urlParams, responseTOClass);
     }
 }

--- a/src/main/java/io/api/etherscan/core/impl/BaseApi.java
+++ b/src/main/java/io/api/etherscan/core/impl/BaseApi.java
@@ -1,0 +1,135 @@
+package io.api.etherscan.core.impl;
+
+import io.api.etherscan.core.*;
+import io.api.etherscan.error.ApiException;
+import io.api.etherscan.error.ApiKeyException;
+import io.api.etherscan.executor.IHttpExecutor;
+import io.api.etherscan.executor.impl.HttpExecutor;
+import io.api.etherscan.manager.IQueueManager;
+import io.api.etherscan.manager.impl.FakeQueueManager;
+import io.api.etherscan.manager.impl.QueueManager;
+import io.api.etherscan.model.EthNetwork;
+import io.api.etherscan.model.network.Network;
+import io.api.etherscan.util.BasicUtils;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.function.Supplier;
+
+public abstract class BaseApi implements AutoCloseable {
+
+    private static final Supplier<IHttpExecutor> DEFAULT_SUPPLIER = HttpExecutor::new;
+
+    public static final String DEFAULT_KEY = "YourApiKeyToken";
+
+    private final IQueueManager queueManager;
+    private final IAccountApi account;
+    private final IBlockApi block;
+    private final IContractApi contract;
+    private final ILogsApi logs;
+    private final IProxyApi proxy;
+    private final IStatisticApi stats;
+    private final ITransactionApi txs;
+
+    public BaseApi() {
+        this(DEFAULT_KEY, EthNetwork.MAINNET);
+    }
+
+    public BaseApi(final Network network) {
+        this(DEFAULT_KEY, network);
+    }
+
+    public BaseApi(final String apiKey) {
+        this(apiKey, EthNetwork.MAINNET);
+    }
+
+    public BaseApi(final Network network,
+                   final Supplier<IHttpExecutor> executorSupplier) {
+        this(DEFAULT_KEY, network, executorSupplier);
+    }
+
+    public BaseApi(final String apiKey,
+                   final Network network,
+                   final IQueueManager queue) {
+        this(apiKey, network, DEFAULT_SUPPLIER, queue);
+    }
+
+    public BaseApi(final String apiKey,
+                   final Network network) {
+        this(apiKey, network, DEFAULT_SUPPLIER);
+    }
+
+    public BaseApi(final String apiKey,
+                   final Network network,
+                   final Supplier<IHttpExecutor> executorSupplier) {
+        this(apiKey, network, executorSupplier,
+                DEFAULT_KEY.equals(apiKey)
+                        ? QueueManager.DEFAULT_KEY_QUEUE
+                        : new FakeQueueManager());
+    }
+
+    public BaseApi(final String apiKey,
+                   final Network network,
+                   final Supplier<IHttpExecutor> executorSupplier,
+                   final IQueueManager queue) {
+        if (BasicUtils.isBlank(apiKey))
+            throw new ApiKeyException("API key can not be null or empty");
+
+        if (network == null)
+            throw new ApiException("Ethereum Network is set to NULL value");
+
+        // EtherScan 1request\5sec limit support by queue manager
+        final IHttpExecutor executor = executorSupplier.get();
+
+        final String baseUrl = network.getUrl() + apiKey;
+
+        this.queueManager = queue;
+        this.account = new AccountApiProvider(queue, baseUrl, executor);
+        this.block = new BlockApiProvider(queue, baseUrl, executor);
+        this.contract = new ContractApiProvider(queue, baseUrl, executor);
+        this.logs = new LogsApiProvider(queue, baseUrl, executor);
+        this.proxy = new ProxyApiProvider(queue, baseUrl, executor);
+        this.stats = new StatisticApiProvider(queue, baseUrl, executor);
+        this.txs = new TransactionApiProvider(queue, baseUrl, executor);
+    }
+
+    @NotNull
+    public IAccountApi account() {
+        return account;
+    }
+
+    @NotNull
+    public IContractApi contract() {
+        return contract;
+    }
+
+    @NotNull
+    public ITransactionApi txs() {
+        return txs;
+    }
+
+    @NotNull
+    public IBlockApi block() {
+        return block;
+    }
+
+    @NotNull
+    public ILogsApi logs() {
+        return logs;
+    }
+
+    @NotNull
+    public IProxyApi proxy() {
+        return proxy;
+    }
+
+    @NotNull
+    public IStatisticApi stats() {
+        return stats;
+    }
+
+    @Override
+    public void close() throws Exception {
+        queueManager.close();
+    }
+
+}

--- a/src/main/java/io/api/etherscan/core/impl/EtherScanApi.java
+++ b/src/main/java/io/api/etherscan/core/impl/EtherScanApi.java
@@ -1,16 +1,8 @@
 package io.api.etherscan.core.impl;
 
-import io.api.etherscan.core.*;
-import io.api.etherscan.error.ApiException;
-import io.api.etherscan.error.ApiKeyException;
 import io.api.etherscan.executor.IHttpExecutor;
-import io.api.etherscan.executor.impl.HttpExecutor;
 import io.api.etherscan.manager.IQueueManager;
-import io.api.etherscan.manager.impl.FakeQueueManager;
-import io.api.etherscan.manager.impl.QueueManager;
 import io.api.etherscan.model.EthNetwork;
-import io.api.etherscan.util.BasicUtils;
-import org.jetbrains.annotations.NotNull;
 
 import java.util.function.Supplier;
 
@@ -20,121 +12,37 @@ import java.util.function.Supplier;
  * @author GoodforGod
  * @since 28.10.2018
  */
-public class EtherScanApi implements AutoCloseable {
-
-    private static final Supplier<IHttpExecutor> DEFAULT_SUPPLIER = HttpExecutor::new;
-
-    public static final String DEFAULT_KEY = "YourApiKeyToken";
-
-    private final IQueueManager queueManager;
-    private final IAccountApi account;
-    private final IBlockApi block;
-    private final IContractApi contract;
-    private final ILogsApi logs;
-    private final IProxyApi proxy;
-    private final IStatisticApi stats;
-    private final ITransactionApi txs;
+public class EtherScanApi extends BaseApi {
 
     public EtherScanApi() {
-        this(DEFAULT_KEY, EthNetwork.MAINNET);
+        super();
     }
 
-    public EtherScanApi(final EthNetwork network) {
-        this(DEFAULT_KEY, network);
+    public EtherScanApi(EthNetwork network) {
+        super(network);
     }
 
-    public EtherScanApi(final String apiKey) {
-        this(apiKey, EthNetwork.MAINNET);
+    public EtherScanApi(String apiKey) {
+        super(apiKey);
     }
 
-    public EtherScanApi(final EthNetwork network,
-                        final Supplier<IHttpExecutor> executorSupplier) {
-        this(DEFAULT_KEY, network, executorSupplier);
+    public EtherScanApi(EthNetwork network, Supplier<IHttpExecutor> executorSupplier) {
+        super(network, executorSupplier);
     }
 
-    public EtherScanApi(final String apiKey,
-                        final EthNetwork network,
-                        final IQueueManager queue) {
-        this(apiKey, network, DEFAULT_SUPPLIER, queue);
+    public EtherScanApi(String apiKey, EthNetwork network, IQueueManager queue) {
+        super(apiKey, network, queue);
     }
 
-    public EtherScanApi(final String apiKey,
-                        final EthNetwork network) {
-        this(apiKey, network, DEFAULT_SUPPLIER);
+    public EtherScanApi(String apiKey, EthNetwork network) {
+        super(apiKey, network);
     }
 
-    public EtherScanApi(final String apiKey,
-                        final EthNetwork network,
-                        final Supplier<IHttpExecutor> executorSupplier) {
-        this(apiKey, network, executorSupplier,
-                DEFAULT_KEY.equals(apiKey)
-                        ? QueueManager.DEFAULT_KEY_QUEUE
-                        : new FakeQueueManager());
+    public EtherScanApi(String apiKey, EthNetwork network, Supplier<IHttpExecutor> executorSupplier) {
+        super(apiKey, network, executorSupplier);
     }
 
-    public EtherScanApi(final String apiKey,
-                        final EthNetwork network,
-                        final Supplier<IHttpExecutor> executorSupplier,
-                        final IQueueManager queue) {
-        if (BasicUtils.isBlank(apiKey))
-            throw new ApiKeyException("API key can not be null or empty");
-
-        if (network == null)
-            throw new ApiException("Ethereum Network is set to NULL value");
-
-        // EtherScan 1request\5sec limit support by queue manager
-        final IHttpExecutor executor = executorSupplier.get();
-
-        final String ending = EthNetwork.TOBALABA.equals(network) ? "com" : "io";
-        final String baseUrl = "https://" + network.getDomain() + ".etherscan." + ending + "/api" + "?apikey=" + apiKey;
-
-        this.queueManager = queue;
-        this.account = new AccountApiProvider(queue, baseUrl, executor);
-        this.block = new BlockApiProvider(queue, baseUrl, executor);
-        this.contract = new ContractApiProvider(queue, baseUrl, executor);
-        this.logs = new LogsApiProvider(queue, baseUrl, executor);
-        this.proxy = new ProxyApiProvider(queue, baseUrl, executor);
-        this.stats = new StatisticApiProvider(queue, baseUrl, executor);
-        this.txs = new TransactionApiProvider(queue, baseUrl, executor);
-    }
-
-    @NotNull
-    public IAccountApi account() {
-        return account;
-    }
-
-    @NotNull
-    public IContractApi contract() {
-        return contract;
-    }
-
-    @NotNull
-    public ITransactionApi txs() {
-        return txs;
-    }
-
-    @NotNull
-    public IBlockApi block() {
-        return block;
-    }
-
-    @NotNull
-    public ILogsApi logs() {
-        return logs;
-    }
-
-    @NotNull
-    public IProxyApi proxy() {
-        return proxy;
-    }
-
-    @NotNull
-    public IStatisticApi stats() {
-        return stats;
-    }
-
-    @Override
-    public void close() throws Exception {
-        queueManager.close();
+    public EtherScanApi(String apiKey, EthNetwork network, Supplier<IHttpExecutor> executorSupplier, IQueueManager queue) {
+        super(apiKey, network, executorSupplier, queue);
     }
 }

--- a/src/main/java/io/api/etherscan/core/impl/PolygonScanApi.java
+++ b/src/main/java/io/api/etherscan/core/impl/PolygonScanApi.java
@@ -1,0 +1,42 @@
+package io.api.etherscan.core.impl;
+
+import io.api.etherscan.executor.IHttpExecutor;
+import io.api.etherscan.manager.IQueueManager;
+import io.api.etherscan.model.network.PolygonNetwork;
+
+import java.util.function.Supplier;
+
+public class PolygonScanApi extends BaseApi {
+
+    public PolygonScanApi() {
+        super(PolygonNetwork.MAINNET);
+    }
+
+    public PolygonScanApi(PolygonNetwork network) {
+        super(network);
+    }
+
+    public PolygonScanApi(String apiKey) {
+        super(apiKey, PolygonNetwork.MAINNET);
+    }
+
+    public PolygonScanApi(PolygonNetwork network, Supplier<IHttpExecutor> executorSupplier) {
+        super(network, executorSupplier);
+    }
+
+    public PolygonScanApi(String apiKey, PolygonNetwork network, IQueueManager queue) {
+        super(apiKey, network, queue);
+    }
+
+    public PolygonScanApi(String apiKey, PolygonNetwork network) {
+        super(apiKey, network);
+    }
+
+    public PolygonScanApi(String apiKey, PolygonNetwork network, Supplier<IHttpExecutor> executorSupplier) {
+        super(apiKey, network, executorSupplier);
+    }
+
+    public PolygonScanApi(String apiKey, PolygonNetwork network, Supplier<IHttpExecutor> executorSupplier, IQueueManager queue) {
+        super(apiKey, network, executorSupplier, queue);
+    }
+}

--- a/src/main/java/io/api/etherscan/model/Address.java
+++ b/src/main/java/io/api/etherscan/model/Address.java
@@ -1,0 +1,54 @@
+package io.api.etherscan.model;
+
+import io.api.etherscan.util.BasicUtils;
+
+import java.util.Objects;
+
+public class Address {
+
+    private final String address;
+
+    private Address(String address) {
+        this.address = address;
+    }
+
+    public static Address of(String address) {
+        BasicUtils.validateAddress(address);
+        return new Address(address);
+    }
+
+    public String getAddress() {
+        return address;
+    }
+
+    public String to64Hex() {
+        String addressWithoutOx = address.substring(2);
+        return "0x" + padLeftZeros(addressWithoutOx);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Address other = (Address) o;
+        return address.equals(other.address);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(address);
+    }
+
+    private String padLeftZeros(String inputString) {
+        if (inputString.length() >= 64) {
+            return inputString;
+        }
+        StringBuilder sb = new StringBuilder();
+        while (sb.length() < 64 - inputString.length()) {
+            sb.append('0');
+        }
+        sb.append(inputString);
+
+        return sb.toString();
+    }
+}

--- a/src/main/java/io/api/etherscan/model/BaseTxToken.java
+++ b/src/main/java/io/api/etherscan/model/BaseTxToken.java
@@ -1,0 +1,59 @@
+package io.api.etherscan.model;
+
+public abstract class BaseTxToken extends BaseTx {
+
+    private long nonce;
+    private String blockHash;
+    private String tokenName;
+    private String tokenSymbol;
+    private int transactionIndex;
+    private long gasPrice;
+    private long cumulativeGasUsed;
+    private long confirmations;
+
+    public long getNonce() {
+        return nonce;
+    }
+
+    public String getBlockHash() {
+        return blockHash;
+    }
+
+    public String getTokenName() {
+        return tokenName;
+    }
+
+    public String getTokenSymbol() {
+        return tokenSymbol;
+    }
+
+    public int getTransactionIndex() {
+        return transactionIndex;
+    }
+
+    public long getGasPrice() {
+        return gasPrice;
+    }
+
+    public long getCumulativeGasUsed() {
+        return cumulativeGasUsed;
+    }
+
+    public long getConfirmations() {
+        return confirmations;
+    }
+
+    @Override
+    public String toString() {
+        return "BaseTxToken{" +
+                "nonce=" + nonce +
+                ", blockHash='" + blockHash + '\'' +
+                ", tokenName='" + tokenName + '\'' +
+                ", tokenSymbol='" + tokenSymbol + '\'' +
+                ", transactionIndex=" + transactionIndex +
+                ", gasPrice=" + gasPrice +
+                ", cumulativeGasUsed=" + cumulativeGasUsed +
+                ", confirmations=" + confirmations +
+                '}' + super.toString();
+    }
+}

--- a/src/main/java/io/api/etherscan/model/EthNetwork.java
+++ b/src/main/java/io/api/etherscan/model/EthNetwork.java
@@ -1,27 +1,42 @@
 package io.api.etherscan.model;
 
+import io.api.etherscan.model.network.Network;
+
 /**
  * ! NO DESCRIPTION !
  *
  * @author GoodforGod
  * @since 28.10.2018
  */
-public enum EthNetwork {
+public enum EthNetwork implements Network {
 
-    MAINNET("api"),
-    ROPSTEN("api-ropsten"),
-    KOVAN("api-kovan"),
-    TOBALABA("api-tobalaba"),
-    GORLI("api-goerli"),
-    RINKEBY("api-rinkeby");
+    MAINNET("api", "io"),
+    ROPSTEN("api-ropsten", "io"),
+    KOVAN("api-kovan", "io"),
+    TOBALABA("api-tobalaba", "com"),
+    GORLI("api-goerli", "io"),
+    RINKEBY("api-rinkeby", "io");
 
     private final String domain;
+    private final String ending;
 
-    EthNetwork(String domain) {
+    EthNetwork(String domain, String ending) {
         this.domain = domain;
+        this.ending = ending;
     }
 
+    @Override
     public String getDomain() {
         return domain;
+    }
+
+    @Override
+    public String getExplorerName() {
+        return "etherscan";
+    }
+
+    @Override
+    public String getEnding() {
+        return ending;
     }
 }

--- a/src/main/java/io/api/etherscan/model/TxErc1155.java
+++ b/src/main/java/io/api/etherscan/model/TxErc1155.java
@@ -1,0 +1,25 @@
+package io.api.etherscan.model;
+
+import java.math.BigInteger;
+
+public class TxErc1155 extends BaseTxToken {
+
+    private BigInteger tokenID;
+    private BigInteger tokenValue;
+
+    public BigInteger getTokenID() {
+        return tokenID;
+    }
+
+    public BigInteger getTokenValue() {
+        return tokenValue;
+    }
+
+    @Override
+    public String toString() {
+        return "TxErc1155{" +
+                "tokenID=" + tokenID +
+                ", tokenValue=" + tokenValue +
+                '}' + super.toString();
+    }
+}

--- a/src/main/java/io/api/etherscan/model/TxErc20.java
+++ b/src/main/java/io/api/etherscan/model/TxErc20.java
@@ -1,0 +1,19 @@
+package io.api.etherscan.model;
+
+import java.math.BigInteger;
+
+public class TxErc20 extends BaseTxToken {
+
+    private BigInteger tokenDecimal;
+
+    public BigInteger getTokenDecimal() {
+        return tokenDecimal;
+    }
+
+    @Override
+    public String toString() {
+        return "TxErc20{" +
+                "tokenDecimal=" + tokenDecimal +
+                '}' + super.toString();
+    }
+}

--- a/src/main/java/io/api/etherscan/model/TxErc721.java
+++ b/src/main/java/io/api/etherscan/model/TxErc721.java
@@ -1,0 +1,25 @@
+package io.api.etherscan.model;
+
+import java.math.BigInteger;
+
+public class TxErc721 extends BaseTxToken {
+
+    private BigInteger tokenID;
+    private BigInteger tokenDecimal;
+
+    public BigInteger getTokenID() {
+        return tokenID;
+    }
+
+    public BigInteger getTokenDecimal() {
+        return tokenDecimal;
+    }
+
+    @Override
+    public String toString() {
+        return "TxErc721{" +
+                "tokenID=" + tokenID +
+                ", tokenDecimal=" + tokenDecimal +
+                '}' + super.toString();
+    }
+}

--- a/src/main/java/io/api/etherscan/model/network/Network.java
+++ b/src/main/java/io/api/etherscan/model/network/Network.java
@@ -1,0 +1,14 @@
+package io.api.etherscan.model.network;
+
+public interface Network {
+
+    String getDomain();
+
+    String getExplorerName();
+
+    String getEnding();
+
+    default String getUrl() {
+        return "https://" + getDomain() + "." + getExplorerName() + "." + getEnding() + "/api?apikey=";
+    }
+}

--- a/src/main/java/io/api/etherscan/model/network/PolygonNetwork.java
+++ b/src/main/java/io/api/etherscan/model/network/PolygonNetwork.java
@@ -1,0 +1,27 @@
+package io.api.etherscan.model.network;
+
+public enum PolygonNetwork implements Network {
+    MAINNET("api"),
+    TESTNET("api-testnet");
+
+    private final String domain;
+
+    PolygonNetwork(String domain) {
+        this.domain = domain;
+    }
+
+    @Override
+    public String getDomain() {
+        return domain;
+    }
+
+    @Override
+    public String getExplorerName() {
+        return "polygonscan";
+    }
+
+    @Override
+    public String getEnding() {
+        return "com";
+    }
+}

--- a/src/main/java/io/api/etherscan/model/query/LogTopic.java
+++ b/src/main/java/io/api/etherscan/model/query/LogTopic.java
@@ -1,0 +1,42 @@
+package io.api.etherscan.model.query;
+
+import io.api.etherscan.model.Address;
+import io.api.etherscan.util.BasicUtils;
+
+import java.util.Objects;
+
+public class LogTopic {
+
+    private final String hex;
+
+    private LogTopic(String hex) {
+        this.hex = hex;
+    }
+
+    public static LogTopic of(Address address) {
+        return of(address.to64Hex());
+    }
+
+    public static LogTopic of(String hex) {
+        BasicUtils.validateTxHash(hex);
+        return new LogTopic(hex);
+    }
+
+    public String getHex() {
+        return hex;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        LogTopic other = (LogTopic) o;
+        return hex.equals(other.hex);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(hex);
+    }
+
+}

--- a/src/main/java/io/api/etherscan/model/query/impl/LogQuery.java
+++ b/src/main/java/io/api/etherscan/model/query/impl/LogQuery.java
@@ -1,6 +1,8 @@
 package io.api.etherscan.model.query.impl;
 
 import io.api.etherscan.core.ILogsApi;
+import io.api.etherscan.model.query.impl.topic.TopicParams;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Final builded container for The Event Log API
@@ -22,6 +24,10 @@ public class LogQuery {
 
     LogQuery(String params) {
         this.params = params;
+    }
+
+    public LogQuery(@NotNull StandardLogQueryParams standardLogQueryParams, @NotNull TopicParams topicParams) {
+        this.params = standardLogQueryParams.getApiParams() + topicParams.getApiParams();
     }
 
     public String getParams() {

--- a/src/main/java/io/api/etherscan/model/query/impl/LogQueryBuilder.java
+++ b/src/main/java/io/api/etherscan/model/query/impl/LogQueryBuilder.java
@@ -3,7 +3,9 @@ package io.api.etherscan.model.query.impl;
 import io.api.etherscan.core.ILogsApi;
 import io.api.etherscan.error.LogQueryException;
 import io.api.etherscan.model.query.IQueryBuilder;
+import io.api.etherscan.model.query.impl.topic.TopicParams;
 import io.api.etherscan.util.BasicUtils;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Builder for The Event Log API
@@ -40,12 +42,20 @@ public class LogQueryBuilder implements IQueryBuilder {
         return new LogQueryBuilder(address, startBlock, endBlock);
     }
 
+    /**
+     * @deprecated use {@link LogQueryBuilder#topic(TopicParams)}
+     */
+    @Deprecated
     public LogTopicSingle topic(String topic0) {
         if (BasicUtils.isNotHex(topic0))
             throw new LogQueryException("topic0 can not be empty or non hex.");
         return new LogTopicSingle(address, startBlock, endBlock, topic0);
     }
 
+    /**
+     * @deprecated use {@link LogQueryBuilder#topic(TopicParams)}
+     */
+    @Deprecated
     public LogTopicTuple topic(String topic0, String topic1) {
         if (BasicUtils.isNotHex(topic0))
             throw new LogQueryException("topic0 can not be empty or non hex.");
@@ -54,6 +64,10 @@ public class LogQueryBuilder implements IQueryBuilder {
         return new LogTopicTuple(address, startBlock, endBlock, topic0, topic1);
     }
 
+    /**
+     * @deprecated use {@link LogQueryBuilder#topic(TopicParams)}
+     */
+    @Deprecated
     public LogTopicTriple topic(String topic0, String topic1, String topic2) {
         if (BasicUtils.isNotHex(topic0))
             throw new LogQueryException("topic0 can not be empty or non hex.");
@@ -64,6 +78,10 @@ public class LogQueryBuilder implements IQueryBuilder {
         return new LogTopicTriple(address, startBlock, endBlock, topic0, topic1, topic2);
     }
 
+    /**
+     * @deprecated use {@link LogQueryBuilder#topic(TopicParams)}
+     */
+    @Deprecated
     public LogTopicQuadro topic(String topic0, String topic1, String topic2, String topic3) {
         if (BasicUtils.isNotHex(topic0))
             throw new LogQueryException("topic0 can not be empty or non hex.");
@@ -75,6 +93,10 @@ public class LogQueryBuilder implements IQueryBuilder {
             throw new LogQueryException("topic3 can not be empty or non hex.");
 
         return new LogTopicQuadro(address, startBlock, endBlock, topic0, topic1, topic2, topic3);
+    }
+
+    public LogQueryWithTopicsBuilder topic(@NotNull TopicParams topicParams) {
+        return new LogQueryWithTopicsBuilder(new StandardLogQueryParams(address, startBlock, endBlock), topicParams);
     }
 
     @Override

--- a/src/main/java/io/api/etherscan/model/query/impl/LogQueryWithTopicsBuilder.java
+++ b/src/main/java/io/api/etherscan/model/query/impl/LogQueryWithTopicsBuilder.java
@@ -1,0 +1,21 @@
+package io.api.etherscan.model.query.impl;
+
+import io.api.etherscan.error.LogQueryException;
+import io.api.etherscan.model.query.IQueryBuilder;
+import io.api.etherscan.model.query.impl.topic.TopicParams;
+
+public class LogQueryWithTopicsBuilder implements IQueryBuilder {
+
+    private final StandardLogQueryParams standardLogQueryParams;
+    private final TopicParams topicParams;
+
+    public LogQueryWithTopicsBuilder(StandardLogQueryParams standardLogQueryParams, TopicParams topicParams) {
+        this.standardLogQueryParams = standardLogQueryParams;
+        this.topicParams = topicParams;
+    }
+
+    @Override
+    public LogQuery build() throws LogQueryException {
+        return new LogQuery(standardLogQueryParams, topicParams);
+    }
+}

--- a/src/main/java/io/api/etherscan/model/query/impl/StandardLogQueryParams.java
+++ b/src/main/java/io/api/etherscan/model/query/impl/StandardLogQueryParams.java
@@ -1,0 +1,21 @@
+package io.api.etherscan.model.query.impl;
+
+public class StandardLogQueryParams {
+
+    private final String address;
+    private final long startBlock;
+    private final long endBlock;
+
+    public StandardLogQueryParams(String address, long startBlock, long endBlock) {
+        this.address = address;
+        this.startBlock = startBlock;
+        this.endBlock = endBlock;
+    }
+
+    public String getApiParams() {
+        return "&address=" + address
+                + "&fromBlock=" + startBlock
+                + "&toBlock=" + endBlock;
+    }
+
+}

--- a/src/main/java/io/api/etherscan/model/query/impl/topic/BaseTopic.java
+++ b/src/main/java/io/api/etherscan/model/query/impl/topic/BaseTopic.java
@@ -1,0 +1,19 @@
+package io.api.etherscan.model.query.impl.topic;
+
+import io.api.etherscan.model.query.LogTopic;
+
+public abstract class BaseTopic {
+
+    private final TopicNr topicNr;
+    private final LogTopic logTopic;
+
+    public BaseTopic(TopicNr topicNr, LogTopic logTopic) {
+        this.topicNr = topicNr;
+        this.logTopic = logTopic;
+    }
+
+    public String getApiParams() {
+        return topicNr.getTopicParam() + logTopic.getHex();
+    }
+
+}

--- a/src/main/java/io/api/etherscan/model/query/impl/topic/TopicNr.java
+++ b/src/main/java/io/api/etherscan/model/query/impl/topic/TopicNr.java
@@ -1,0 +1,18 @@
+package io.api.etherscan.model.query.impl.topic;
+
+enum TopicNr {
+    TOPIC_0("&topic0="),
+    TOPIC_1("&topic1="),
+    TOPIC_2("&topic2="),
+    TOPIC_3("&topic3=");
+
+    private final String topicParam;
+
+    TopicNr(String topicParam) {
+        this.topicParam = topicParam;
+    }
+
+    public String getTopicParam() {
+        return topicParam;
+    }
+}

--- a/src/main/java/io/api/etherscan/model/query/impl/topic/TopicOne.java
+++ b/src/main/java/io/api/etherscan/model/query/impl/topic/TopicOne.java
@@ -1,0 +1,10 @@
+package io.api.etherscan.model.query.impl.topic;
+
+import io.api.etherscan.model.query.LogTopic;
+
+public class TopicOne extends BaseTopic{
+
+    public TopicOne(LogTopic logTopic) {
+        super(TopicNr.TOPIC_1, logTopic);
+    }
+}

--- a/src/main/java/io/api/etherscan/model/query/impl/topic/TopicParams.java
+++ b/src/main/java/io/api/etherscan/model/query/impl/topic/TopicParams.java
@@ -1,0 +1,6 @@
+package io.api.etherscan.model.query.impl.topic;
+
+public interface TopicParams {
+
+    String getApiParams();
+}

--- a/src/main/java/io/api/etherscan/model/query/impl/topic/TopicParamsFactory.java
+++ b/src/main/java/io/api/etherscan/model/query/impl/topic/TopicParamsFactory.java
@@ -1,0 +1,115 @@
+package io.api.etherscan.model.query.impl.topic;
+
+import io.api.etherscan.model.query.impl.topic.operator.*;
+import io.api.etherscan.model.query.impl.topic.pair.*;
+import io.api.etherscan.model.query.impl.topic.quadruple.TopicQuadruple;
+import io.api.etherscan.model.query.impl.topic.single.SingleTopic;
+import io.api.etherscan.model.query.impl.topic.triple.TopicTripleOneTwoThree;
+import io.api.etherscan.model.query.impl.topic.triple.TopicTripleZeroOneThree;
+import io.api.etherscan.model.query.impl.topic.triple.TopicTripleZeroOneTwo;
+import io.api.etherscan.model.query.impl.topic.triple.TopicTripleZeroTwoThree;
+
+public class TopicParamsFactory {
+
+    /**
+     * Factory Method for single Topic
+     */
+
+    public static TopicParams of(BaseTopic topic) {
+        return new SingleTopic(topic);
+    }
+
+    /**
+     * Factory Methods for TopicPairs
+     */
+
+    public static TopicParams of(TopicZero topicZero, TopicOne topicOne, LogOperatorZeroOne operator) {
+        return new TopicPairZeroOne(topicZero, topicOne, operator);
+    }
+
+    public static TopicParams of(TopicZero topicZero, TopicTwo topicTwo, LogOperatorZeroTwo operator) {
+        return new TopicPairZeroTwo(topicZero, topicTwo, operator);
+    }
+
+    public static TopicParams of(TopicZero topicZero, TopicThree topicThree, LogOperatorZeroThree operator) {
+        return new TopicPairZeroThree(topicZero, topicThree, operator);
+    }
+
+    public static TopicParams of(TopicOne topicOne, TopicTwo topicTwo, LogOperatorOneTwo operator) {
+        return new TopicPairOneTwo(topicOne, topicTwo, operator);
+    }
+
+    public static TopicParams of(TopicOne topicOne, TopicThree topicThree, LogOperatorOneThree operator) {
+        return new TopicPairOneThree(topicOne, topicThree, operator);
+    }
+
+    public static TopicParams of(TopicTwo topicTwo, TopicThree topicThree, LogOperatorTwoThree operator) {
+        return new TopicPairTwoThree(topicTwo, topicThree, operator);
+    }
+
+    /**
+     * Factory Methods for TopicTriples
+     */
+
+    public static TopicParams of(TopicZero topicZero,
+                                 TopicOne topicOne,
+                                 TopicTwo topicTwo,
+                                 LogOperatorZeroOne operatorZeroOne,
+                                 LogOperatorZeroTwo operatorZeroTwo,
+                                 LogOperatorOneTwo operatorOneTwo) {
+        return new TopicTripleZeroOneTwo(topicZero, topicOne, topicTwo, operatorZeroOne, operatorZeroTwo, operatorOneTwo);
+    }
+
+    public static TopicParams of(TopicZero topicZero,
+                                 TopicOne topicOne,
+                                 TopicThree topicThree,
+                                 LogOperatorZeroOne operatorZeroOne,
+                                 LogOperatorZeroThree operatorZeroThree,
+                                 LogOperatorOneThree operatorOneThree) {
+        return new TopicTripleZeroOneThree(topicZero, topicOne, topicThree, operatorZeroOne, operatorZeroThree, operatorOneThree);
+    }
+
+    public static TopicParams of(TopicZero topicZero,
+                                 TopicTwo topicTwo,
+                                 TopicThree topicThree,
+                                 LogOperatorZeroTwo operatorZeroTwo,
+                                 LogOperatorZeroThree operatorZeroThree,
+                                 LogOperatorTwoThree operatorTwoThree) {
+        return new TopicTripleZeroTwoThree(topicZero, topicTwo, topicThree, operatorZeroTwo, operatorZeroThree, operatorTwoThree);
+    }
+
+    public static TopicParams of(TopicOne topicOne,
+                                 TopicTwo topicTwo,
+                                 TopicThree topicThree,
+                                 LogOperatorOneTwo operatorOneTwo,
+                                 LogOperatorOneThree operatorOneThree,
+                                 LogOperatorTwoThree operatorTwoThree) {
+        return new TopicTripleOneTwoThree(topicOne, topicTwo, topicThree, operatorOneTwo, operatorOneThree, operatorTwoThree);
+    }
+
+    /**
+     * Factory Method for TopicQuadruple
+     */
+
+    public static TopicParams of(TopicZero topicZero,
+                                 TopicOne topicOne,
+                                 TopicTwo topicTwo,
+                                 TopicThree topicThree,
+                                 LogOperatorZeroOne operatorZeroOne,
+                                 LogOperatorZeroTwo operatorZeroTwo,
+                                 LogOperatorZeroThree operatorZeroThree,
+                                 LogOperatorOneTwo operatorOneTwo,
+                                 LogOperatorOneThree operatorOneThree,
+                                 LogOperatorTwoThree operatorTwoThree) {
+        return new TopicQuadruple(topicZero,
+                topicOne,
+                topicTwo,
+                topicThree,
+                operatorZeroOne,
+                operatorZeroTwo,
+                operatorZeroThree,
+                operatorOneTwo,
+                operatorOneThree,
+                operatorTwoThree);
+    }
+}

--- a/src/main/java/io/api/etherscan/model/query/impl/topic/TopicThree.java
+++ b/src/main/java/io/api/etherscan/model/query/impl/topic/TopicThree.java
@@ -1,0 +1,10 @@
+package io.api.etherscan.model.query.impl.topic;
+
+import io.api.etherscan.model.query.LogTopic;
+
+public class TopicThree extends BaseTopic {
+
+    public TopicThree(LogTopic logTopic) {
+        super(TopicNr.TOPIC_3, logTopic);
+    }
+}

--- a/src/main/java/io/api/etherscan/model/query/impl/topic/TopicTwo.java
+++ b/src/main/java/io/api/etherscan/model/query/impl/topic/TopicTwo.java
@@ -1,0 +1,10 @@
+package io.api.etherscan.model.query.impl.topic;
+
+import io.api.etherscan.model.query.LogTopic;
+
+public class TopicTwo extends BaseTopic {
+
+    public TopicTwo(LogTopic logTopic) {
+        super(TopicNr.TOPIC_2, logTopic);
+    }
+}

--- a/src/main/java/io/api/etherscan/model/query/impl/topic/TopicZero.java
+++ b/src/main/java/io/api/etherscan/model/query/impl/topic/TopicZero.java
@@ -1,0 +1,10 @@
+package io.api.etherscan.model.query.impl.topic;
+
+import io.api.etherscan.model.query.LogTopic;
+
+public class TopicZero extends BaseTopic {
+
+    public TopicZero(LogTopic logTopic) {
+        super(TopicNr.TOPIC_0, logTopic);
+    }
+}

--- a/src/main/java/io/api/etherscan/model/query/impl/topic/operator/BaseLogOperator.java
+++ b/src/main/java/io/api/etherscan/model/query/impl/topic/operator/BaseLogOperator.java
@@ -1,0 +1,20 @@
+package io.api.etherscan.model.query.impl.topic.operator;
+
+import io.api.etherscan.model.query.LogOp;
+import io.api.etherscan.model.query.impl.topic.TopicParams;
+
+public abstract class BaseLogOperator implements TopicParams {
+
+    private final LogOperatorParams operatorParams;
+    private final LogOp operator;
+
+    public BaseLogOperator(LogOperatorParams operatorParams, LogOp operator) {
+        this.operatorParams = operatorParams;
+        this.operator = operator;
+    }
+
+    @Override
+    public String getApiParams() {
+        return operatorParams.getApiParameter() + operator.getOperation();
+    }
+}

--- a/src/main/java/io/api/etherscan/model/query/impl/topic/operator/LogOperatorOneThree.java
+++ b/src/main/java/io/api/etherscan/model/query/impl/topic/operator/LogOperatorOneThree.java
@@ -1,0 +1,10 @@
+package io.api.etherscan.model.query.impl.topic.operator;
+
+import io.api.etherscan.model.query.LogOp;
+
+public class LogOperatorOneThree extends BaseLogOperator{
+
+    public LogOperatorOneThree(LogOp operator) {
+        super(LogOperatorParams.TOPIC_1_3, operator);
+    }
+}

--- a/src/main/java/io/api/etherscan/model/query/impl/topic/operator/LogOperatorOneTwo.java
+++ b/src/main/java/io/api/etherscan/model/query/impl/topic/operator/LogOperatorOneTwo.java
@@ -1,0 +1,10 @@
+package io.api.etherscan.model.query.impl.topic.operator;
+
+import io.api.etherscan.model.query.LogOp;
+
+public class LogOperatorOneTwo extends BaseLogOperator {
+
+    public LogOperatorOneTwo(LogOp operator) {
+        super(LogOperatorParams.TOPIC_1_2, operator);
+    }
+}

--- a/src/main/java/io/api/etherscan/model/query/impl/topic/operator/LogOperatorParams.java
+++ b/src/main/java/io/api/etherscan/model/query/impl/topic/operator/LogOperatorParams.java
@@ -1,0 +1,20 @@
+package io.api.etherscan.model.query.impl.topic.operator;
+
+public enum LogOperatorParams {
+    TOPIC_0_1("&topic0_1_opr="),
+    TOPIC_0_2("&topic0_2_opr="),
+    TOPIC_0_3("&topic0_3_opr="),
+    TOPIC_1_2("&topic1_2_opr="),
+    TOPIC_1_3("&topic1_3_opr="),
+    TOPIC_2_3("&topic2_3_opr=");
+
+    private final String apiParameter;
+
+    LogOperatorParams(String apiParameter) {
+        this.apiParameter = apiParameter;
+    }
+
+    public String getApiParameter() {
+        return apiParameter;
+    }
+}

--- a/src/main/java/io/api/etherscan/model/query/impl/topic/operator/LogOperatorTwoThree.java
+++ b/src/main/java/io/api/etherscan/model/query/impl/topic/operator/LogOperatorTwoThree.java
@@ -1,0 +1,10 @@
+package io.api.etherscan.model.query.impl.topic.operator;
+
+import io.api.etherscan.model.query.LogOp;
+
+public class LogOperatorTwoThree extends BaseLogOperator {
+
+    public LogOperatorTwoThree(LogOp operator) {
+        super(LogOperatorParams.TOPIC_2_3, operator);
+    }
+}

--- a/src/main/java/io/api/etherscan/model/query/impl/topic/operator/LogOperatorZeroOne.java
+++ b/src/main/java/io/api/etherscan/model/query/impl/topic/operator/LogOperatorZeroOne.java
@@ -1,0 +1,10 @@
+package io.api.etherscan.model.query.impl.topic.operator;
+
+import io.api.etherscan.model.query.LogOp;
+
+public class LogOperatorZeroOne extends BaseLogOperator{
+
+    public LogOperatorZeroOne(LogOp operator) {
+        super(LogOperatorParams.TOPIC_0_1, operator);
+    }
+}

--- a/src/main/java/io/api/etherscan/model/query/impl/topic/operator/LogOperatorZeroThree.java
+++ b/src/main/java/io/api/etherscan/model/query/impl/topic/operator/LogOperatorZeroThree.java
@@ -1,0 +1,10 @@
+package io.api.etherscan.model.query.impl.topic.operator;
+
+import io.api.etherscan.model.query.LogOp;
+
+public class LogOperatorZeroThree extends BaseLogOperator {
+
+    public LogOperatorZeroThree(LogOp operator) {
+        super(LogOperatorParams.TOPIC_0_3, operator);
+    }
+}

--- a/src/main/java/io/api/etherscan/model/query/impl/topic/operator/LogOperatorZeroTwo.java
+++ b/src/main/java/io/api/etherscan/model/query/impl/topic/operator/LogOperatorZeroTwo.java
@@ -1,0 +1,10 @@
+package io.api.etherscan.model.query.impl.topic.operator;
+
+import io.api.etherscan.model.query.LogOp;
+
+public class LogOperatorZeroTwo extends BaseLogOperator{
+
+    public LogOperatorZeroTwo(LogOp operator) {
+        super(LogOperatorParams.TOPIC_0_2, operator);
+    }
+}

--- a/src/main/java/io/api/etherscan/model/query/impl/topic/pair/BaseTopicPair.java
+++ b/src/main/java/io/api/etherscan/model/query/impl/topic/pair/BaseTopicPair.java
@@ -1,0 +1,25 @@
+package io.api.etherscan.model.query.impl.topic.pair;
+
+import io.api.etherscan.model.query.impl.topic.BaseTopic;
+import io.api.etherscan.model.query.impl.topic.TopicParams;
+import io.api.etherscan.model.query.impl.topic.operator.BaseLogOperator;
+
+public abstract class BaseTopicPair implements TopicParams {
+
+    private final BaseTopic topicA;
+    private final BaseTopic topicB;
+    private final BaseLogOperator operator;
+
+    public BaseTopicPair(BaseTopic topicA, BaseTopic topicB, BaseLogOperator operator) {
+        this.topicA = topicA;
+        this.topicB = topicB;
+        this.operator = operator;
+    }
+
+    @Override
+    public String getApiParams() {
+        return topicA.getApiParams()
+                + topicB.getApiParams()
+                + operator.getApiParams();
+    }
+}

--- a/src/main/java/io/api/etherscan/model/query/impl/topic/pair/TopicPairOneThree.java
+++ b/src/main/java/io/api/etherscan/model/query/impl/topic/pair/TopicPairOneThree.java
@@ -1,0 +1,13 @@
+package io.api.etherscan.model.query.impl.topic.pair;
+
+import io.api.etherscan.model.query.impl.topic.TopicOne;
+import io.api.etherscan.model.query.impl.topic.TopicThree;
+import io.api.etherscan.model.query.impl.topic.operator.LogOperatorOneThree;
+
+public class TopicPairOneThree extends BaseTopicPair {
+
+    public TopicPairOneThree(TopicOne topicOne, TopicThree topicThree, LogOperatorOneThree operator) {
+        super(topicOne, topicThree, operator);
+    }
+
+}

--- a/src/main/java/io/api/etherscan/model/query/impl/topic/pair/TopicPairOneTwo.java
+++ b/src/main/java/io/api/etherscan/model/query/impl/topic/pair/TopicPairOneTwo.java
@@ -1,0 +1,13 @@
+package io.api.etherscan.model.query.impl.topic.pair;
+
+import io.api.etherscan.model.query.impl.topic.TopicOne;
+import io.api.etherscan.model.query.impl.topic.TopicTwo;
+import io.api.etherscan.model.query.impl.topic.operator.LogOperatorOneTwo;
+
+public class TopicPairOneTwo extends BaseTopicPair {
+
+    public TopicPairOneTwo(TopicOne topicOne, TopicTwo topicTwo, LogOperatorOneTwo operator) {
+        super(topicOne, topicTwo, operator);
+    }
+
+}

--- a/src/main/java/io/api/etherscan/model/query/impl/topic/pair/TopicPairTwoThree.java
+++ b/src/main/java/io/api/etherscan/model/query/impl/topic/pair/TopicPairTwoThree.java
@@ -1,0 +1,13 @@
+package io.api.etherscan.model.query.impl.topic.pair;
+
+import io.api.etherscan.model.query.impl.topic.TopicThree;
+import io.api.etherscan.model.query.impl.topic.TopicTwo;
+import io.api.etherscan.model.query.impl.topic.operator.LogOperatorTwoThree;
+
+public class TopicPairTwoThree extends BaseTopicPair {
+
+    public TopicPairTwoThree(TopicTwo topicTwo, TopicThree topicThree, LogOperatorTwoThree operator) {
+        super(topicTwo, topicThree, operator);
+    }
+
+}

--- a/src/main/java/io/api/etherscan/model/query/impl/topic/pair/TopicPairZeroOne.java
+++ b/src/main/java/io/api/etherscan/model/query/impl/topic/pair/TopicPairZeroOne.java
@@ -1,0 +1,13 @@
+package io.api.etherscan.model.query.impl.topic.pair;
+
+import io.api.etherscan.model.query.impl.topic.TopicOne;
+import io.api.etherscan.model.query.impl.topic.TopicZero;
+import io.api.etherscan.model.query.impl.topic.operator.LogOperatorZeroOne;
+
+public class TopicPairZeroOne extends BaseTopicPair {
+
+    public TopicPairZeroOne(TopicZero topicZero, TopicOne topicOne, LogOperatorZeroOne operator) {
+        super(topicZero, topicOne, operator);
+    }
+
+}

--- a/src/main/java/io/api/etherscan/model/query/impl/topic/pair/TopicPairZeroThree.java
+++ b/src/main/java/io/api/etherscan/model/query/impl/topic/pair/TopicPairZeroThree.java
@@ -1,0 +1,13 @@
+package io.api.etherscan.model.query.impl.topic.pair;
+
+import io.api.etherscan.model.query.impl.topic.TopicThree;
+import io.api.etherscan.model.query.impl.topic.TopicZero;
+import io.api.etherscan.model.query.impl.topic.operator.LogOperatorZeroThree;
+
+public class TopicPairZeroThree extends BaseTopicPair {
+
+    public TopicPairZeroThree(TopicZero topicZero, TopicThree topicThree, LogOperatorZeroThree operator) {
+        super(topicZero, topicThree, operator);
+    }
+
+}

--- a/src/main/java/io/api/etherscan/model/query/impl/topic/pair/TopicPairZeroTwo.java
+++ b/src/main/java/io/api/etherscan/model/query/impl/topic/pair/TopicPairZeroTwo.java
@@ -1,0 +1,13 @@
+package io.api.etherscan.model.query.impl.topic.pair;
+
+import io.api.etherscan.model.query.impl.topic.TopicTwo;
+import io.api.etherscan.model.query.impl.topic.TopicZero;
+import io.api.etherscan.model.query.impl.topic.operator.LogOperatorZeroTwo;
+
+public class TopicPairZeroTwo extends BaseTopicPair {
+
+    public TopicPairZeroTwo(TopicZero topicZero, TopicTwo topicTwo, LogOperatorZeroTwo operator) {
+        super(topicZero, topicTwo, operator);
+    }
+
+}

--- a/src/main/java/io/api/etherscan/model/query/impl/topic/quadruple/TopicQuadruple.java
+++ b/src/main/java/io/api/etherscan/model/query/impl/topic/quadruple/TopicQuadruple.java
@@ -1,0 +1,54 @@
+package io.api.etherscan.model.query.impl.topic.quadruple;
+
+import io.api.etherscan.model.query.impl.topic.*;
+import io.api.etherscan.model.query.impl.topic.operator.*;
+
+public class TopicQuadruple implements TopicParams {
+
+    private final TopicZero topicZero;
+    private final TopicOne topicOne;
+    private final TopicTwo topicTwo;
+    private final TopicThree topicThree;
+    private final LogOperatorZeroOne operatorZeroOne;
+    private final LogOperatorZeroTwo operatorZeroTwo;
+    private final LogOperatorZeroThree operatorZeroThree;
+    private final LogOperatorOneTwo operatorOneTwo;
+    private final LogOperatorOneThree operatorOneThree;
+    private final LogOperatorTwoThree operatorTwoThree;
+
+    public TopicQuadruple(TopicZero topicZero,
+                          TopicOne topicOne,
+                          TopicTwo topicTwo,
+                          TopicThree topicThree,
+                          LogOperatorZeroOne operatorZeroOne,
+                          LogOperatorZeroTwo operatorZeroTwo,
+                          LogOperatorZeroThree operatorZeroThree,
+                          LogOperatorOneTwo operatorOneTwo,
+                          LogOperatorOneThree operatorOneThree,
+                          LogOperatorTwoThree operatorTwoThree) {
+        this.topicZero = topicZero;
+        this.topicOne = topicOne;
+        this.topicTwo = topicTwo;
+        this.topicThree = topicThree;
+        this.operatorZeroOne = operatorZeroOne;
+        this.operatorZeroTwo = operatorZeroTwo;
+        this.operatorZeroThree = operatorZeroThree;
+        this.operatorOneTwo = operatorOneTwo;
+        this.operatorOneThree = operatorOneThree;
+        this.operatorTwoThree = operatorTwoThree;
+    }
+
+    @Override
+    public String getApiParams() {
+        return topicZero.getApiParams()
+                + topicOne.getApiParams()
+                + topicTwo.getApiParams()
+                + topicThree.getApiParams()
+                + operatorZeroOne.getApiParams()
+                + operatorZeroTwo.getApiParams()
+                + operatorZeroThree.getApiParams()
+                + operatorOneTwo.getApiParams()
+                + operatorOneThree.getApiParams()
+                + operatorTwoThree.getApiParams();
+    }
+}

--- a/src/main/java/io/api/etherscan/model/query/impl/topic/single/SingleTopic.java
+++ b/src/main/java/io/api/etherscan/model/query/impl/topic/single/SingleTopic.java
@@ -1,0 +1,18 @@
+package io.api.etherscan.model.query.impl.topic.single;
+
+import io.api.etherscan.model.query.impl.topic.BaseTopic;
+import io.api.etherscan.model.query.impl.topic.TopicParams;
+
+public class SingleTopic implements TopicParams {
+
+    private final BaseTopic topic;
+
+    public SingleTopic(BaseTopic topic) {
+        this.topic = topic;
+    }
+
+    @Override
+    public String getApiParams() {
+        return topic.getApiParams();
+    }
+}

--- a/src/main/java/io/api/etherscan/model/query/impl/topic/triple/BaseTopicTriple.java
+++ b/src/main/java/io/api/etherscan/model/query/impl/topic/triple/BaseTopicTriple.java
@@ -1,0 +1,39 @@
+package io.api.etherscan.model.query.impl.topic.triple;
+
+import io.api.etherscan.model.query.impl.topic.BaseTopic;
+import io.api.etherscan.model.query.impl.topic.TopicParams;
+import io.api.etherscan.model.query.impl.topic.operator.BaseLogOperator;
+
+public abstract class BaseTopicTriple implements TopicParams {
+
+    private final BaseTopic topicA;
+    private final BaseTopic topicB;
+    private final BaseTopic topicC;
+    private final BaseLogOperator operatorAToB;
+    private final BaseLogOperator operatorAToC;
+    private final BaseLogOperator operatorBToC;
+
+    public BaseTopicTriple(BaseTopic topicA,
+                           BaseTopic topicB,
+                           BaseTopic topicC,
+                           BaseLogOperator operatorAToB,
+                           BaseLogOperator operatorAToC,
+                           BaseLogOperator operatorBToC) {
+        this.topicA = topicA;
+        this.topicB = topicB;
+        this.topicC = topicC;
+        this.operatorAToB = operatorAToB;
+        this.operatorAToC = operatorAToC;
+        this.operatorBToC = operatorBToC;
+    }
+
+    @Override
+    public String getApiParams() {
+        return topicA.getApiParams()
+                + topicB.getApiParams()
+                + topicC.getApiParams()
+                + operatorAToB.getApiParams()
+                + operatorAToC.getApiParams()
+                + operatorBToC.getApiParams();
+    }
+}

--- a/src/main/java/io/api/etherscan/model/query/impl/topic/triple/TopicTripleOneTwoThree.java
+++ b/src/main/java/io/api/etherscan/model/query/impl/topic/triple/TopicTripleOneTwoThree.java
@@ -1,0 +1,20 @@
+package io.api.etherscan.model.query.impl.topic.triple;
+
+import io.api.etherscan.model.query.impl.topic.TopicOne;
+import io.api.etherscan.model.query.impl.topic.TopicThree;
+import io.api.etherscan.model.query.impl.topic.TopicTwo;
+import io.api.etherscan.model.query.impl.topic.operator.LogOperatorOneThree;
+import io.api.etherscan.model.query.impl.topic.operator.LogOperatorOneTwo;
+import io.api.etherscan.model.query.impl.topic.operator.LogOperatorTwoThree;
+
+public class TopicTripleOneTwoThree extends BaseTopicTriple {
+
+    public TopicTripleOneTwoThree(TopicOne topicOne,
+                                  TopicTwo topicTwo,
+                                  TopicThree topicThree,
+                                  LogOperatorOneTwo operatorOneTwo,
+                                  LogOperatorOneThree operatorOneThree,
+                                  LogOperatorTwoThree operatorTwoThree) {
+        super(topicOne, topicTwo, topicThree, operatorOneTwo, operatorOneThree, operatorTwoThree);
+    }
+}

--- a/src/main/java/io/api/etherscan/model/query/impl/topic/triple/TopicTripleZeroOneThree.java
+++ b/src/main/java/io/api/etherscan/model/query/impl/topic/triple/TopicTripleZeroOneThree.java
@@ -1,0 +1,20 @@
+package io.api.etherscan.model.query.impl.topic.triple;
+
+import io.api.etherscan.model.query.impl.topic.TopicOne;
+import io.api.etherscan.model.query.impl.topic.TopicThree;
+import io.api.etherscan.model.query.impl.topic.TopicZero;
+import io.api.etherscan.model.query.impl.topic.operator.LogOperatorOneThree;
+import io.api.etherscan.model.query.impl.topic.operator.LogOperatorZeroOne;
+import io.api.etherscan.model.query.impl.topic.operator.LogOperatorZeroThree;
+
+public class TopicTripleZeroOneThree extends BaseTopicTriple {
+
+    public TopicTripleZeroOneThree(TopicZero topicZero,
+                                   TopicOne topicOne,
+                                   TopicThree topicThree,
+                                   LogOperatorZeroOne operatorZeroOne,
+                                   LogOperatorZeroThree operatorZeroThree,
+                                   LogOperatorOneThree operatorOneThree) {
+        super(topicZero, topicOne, topicThree, operatorZeroOne, operatorZeroThree, operatorOneThree);
+    }
+}

--- a/src/main/java/io/api/etherscan/model/query/impl/topic/triple/TopicTripleZeroOneTwo.java
+++ b/src/main/java/io/api/etherscan/model/query/impl/topic/triple/TopicTripleZeroOneTwo.java
@@ -1,0 +1,21 @@
+package io.api.etherscan.model.query.impl.topic.triple;
+
+import io.api.etherscan.model.query.impl.topic.TopicOne;
+import io.api.etherscan.model.query.impl.topic.TopicTwo;
+import io.api.etherscan.model.query.impl.topic.TopicZero;
+import io.api.etherscan.model.query.impl.topic.operator.LogOperatorOneTwo;
+import io.api.etherscan.model.query.impl.topic.operator.LogOperatorZeroOne;
+import io.api.etherscan.model.query.impl.topic.operator.LogOperatorZeroTwo;
+
+public class TopicTripleZeroOneTwo extends BaseTopicTriple {
+
+    public TopicTripleZeroOneTwo(TopicZero topicZero,
+                                 TopicOne topicOne,
+                                 TopicTwo topicTwo,
+                                 LogOperatorZeroOne operatorZeroOne,
+                                 LogOperatorZeroTwo operatorZeroTwo,
+                                 LogOperatorOneTwo operatorOneTwo) {
+        super(topicZero, topicOne, topicTwo, operatorZeroOne, operatorZeroTwo, operatorOneTwo);
+    }
+
+}

--- a/src/main/java/io/api/etherscan/model/query/impl/topic/triple/TopicTripleZeroTwoThree.java
+++ b/src/main/java/io/api/etherscan/model/query/impl/topic/triple/TopicTripleZeroTwoThree.java
@@ -1,0 +1,20 @@
+package io.api.etherscan.model.query.impl.topic.triple;
+
+import io.api.etherscan.model.query.impl.topic.TopicThree;
+import io.api.etherscan.model.query.impl.topic.TopicTwo;
+import io.api.etherscan.model.query.impl.topic.TopicZero;
+import io.api.etherscan.model.query.impl.topic.operator.LogOperatorTwoThree;
+import io.api.etherscan.model.query.impl.topic.operator.LogOperatorZeroThree;
+import io.api.etherscan.model.query.impl.topic.operator.LogOperatorZeroTwo;
+
+public class TopicTripleZeroTwoThree extends BaseTopicTriple {
+
+    public TopicTripleZeroTwoThree(TopicZero topicZero,
+                                   TopicTwo topicTwo,
+                                   TopicThree topicThree,
+                                   LogOperatorZeroTwo operatorZeroTwo,
+                                   LogOperatorZeroThree operatorZeroThree,
+                                   LogOperatorTwoThree operatorTwoThree) {
+        super(topicZero, topicTwo, topicThree, operatorZeroTwo, operatorZeroThree, operatorTwoThree);
+    }
+}

--- a/src/main/java/io/api/etherscan/model/utility/TxErc1155ResponseTO.java
+++ b/src/main/java/io/api/etherscan/model/utility/TxErc1155ResponseTO.java
@@ -1,0 +1,6 @@
+package io.api.etherscan.model.utility;
+
+import io.api.etherscan.model.TxErc1155;
+
+public class TxErc1155ResponseTO extends BaseListResponseTO<TxErc1155> {
+}

--- a/src/main/java/io/api/etherscan/model/utility/TxErc20ResponseTO.java
+++ b/src/main/java/io/api/etherscan/model/utility/TxErc20ResponseTO.java
@@ -1,0 +1,6 @@
+package io.api.etherscan.model.utility;
+
+import io.api.etherscan.model.TxErc20;
+
+public class TxErc20ResponseTO extends BaseListResponseTO<TxErc20> {
+}

--- a/src/main/java/io/api/etherscan/model/utility/TxErc721ResponseTO.java
+++ b/src/main/java/io/api/etherscan/model/utility/TxErc721ResponseTO.java
@@ -1,0 +1,6 @@
+package io.api.etherscan.model.utility;
+
+import io.api.etherscan.model.TxErc721;
+
+public class TxErc721ResponseTO extends BaseListResponseTO<TxErc721> {
+}

--- a/src/test/java/io/api/etherscan/PolygonScanApiTest.java
+++ b/src/test/java/io/api/etherscan/PolygonScanApiTest.java
@@ -1,0 +1,116 @@
+package io.api.etherscan;
+
+import io.api.etherscan.core.impl.PolygonScanApi;
+import io.api.etherscan.error.ApiException;
+import io.api.etherscan.error.ApiKeyException;
+import io.api.etherscan.executor.IHttpExecutor;
+import io.api.etherscan.executor.impl.HttpExecutor;
+import io.api.etherscan.model.*;
+import io.api.etherscan.model.network.PolygonNetwork;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Supplier;
+
+public class PolygonScanApiTest extends Assert {
+
+    private static final String RANDOM_ACCOUNT_1 = "0xDD7CF7Ae4E367eccb90c0f81F5Dbfd72b1FFfFdC";
+    private static final String RANDOM_ACCOUNT_2 = "0x0EB6e8db98Fb33e7027A18A07f4E552cb44CDA0b";
+
+    private final PolygonNetwork network = PolygonNetwork.TESTNET;
+    private final String validKey = "YourKey";
+
+    @Test
+    public void validKey() {
+        PolygonScanApi api = new PolygonScanApi(validKey, network);
+        assertNotNull(api);
+    }
+
+    @Test(expected = ApiKeyException.class)
+    public void emptyKey() {
+        new PolygonScanApi("");
+    }
+
+    @Test(expected = ApiKeyException.class)
+    public void blankKey() {
+        new PolygonScanApi("         ", network);
+    }
+
+    @Test(expected = ApiException.class)
+    public void nullNetwork() {
+        PolygonScanApi api = new PolygonScanApi(validKey, null);
+        assertNotNull(api);
+    }
+
+    @Test
+    public void noTimeoutOnRead() {
+        Supplier<IHttpExecutor> supplier = () -> new HttpExecutor(300);
+        PolygonScanApi api = new PolygonScanApi(PolygonNetwork.MAINNET, supplier);
+        Balance balance = api.account().balance("0xF318ABc9A5a92357c4Fea8d082dade4D43e780B7");
+        assertNotNull(balance);
+    }
+
+    @Test
+    public void accounts_singleAddress() {
+        Balance balance1 = new PolygonScanApi().account().balance(RANDOM_ACCOUNT_1);
+        assertNotNull(balance1);
+        assertNotNull(balance1.getWei());
+
+        Balance balance2 = new PolygonScanApi().account().balance(RANDOM_ACCOUNT_2);
+        assertNotNull(balance2);
+        assertNotNull(balance2.getWei());
+    }
+
+    @Test
+    public void accounts_multpleAddresses() {
+        List<Balance> balances = new PolygonScanApi().account().balances(Arrays.asList(RANDOM_ACCOUNT_1, RANDOM_ACCOUNT_2));
+        assertEquals(2, balances.size());
+        Balance balance1 = balances.get(0);
+        assertNotNull(balance1);
+        assertNotNull(balance1.getWei());
+        Balance balance2 = balances.get(1);
+        assertNotNull(balance2);
+        assertNotNull(balance2.getWei());
+    }
+
+    @Test
+    public void accounts_normalTransactions() {
+        List<Tx> txs = new PolygonScanApi().account().txs(RANDOM_ACCOUNT_1);
+        assertFalse(txs.isEmpty());
+    }
+
+    @Test
+    public void accounts_internalTransactions() {
+        List<TxInternal> txInternals = new PolygonScanApi().account().txsInternal(RANDOM_ACCOUNT_2);
+        assertFalse(txInternals.isEmpty());
+    }
+
+    @Test
+    public void accounts_internalTransactionsByHash() {
+        String hash = "0x8c418e9f1a9c565ecf5304d17179b0aa4b63351011d8dbaf15ccdf57ce9124b0";
+        List<TxInternal> txInternals = new PolygonScanApi().account().txsInternalByHash(hash);
+        assertFalse(txInternals.isEmpty());
+    }
+
+    @Test
+    public void accountsTokenTransactions() {
+        List<TxToken> txTokens = new PolygonScanApi().account().txsToken(RANDOM_ACCOUNT_1);
+        assertFalse(txTokens.isEmpty());
+    }
+
+    @Test
+    public void accounts_NftTransactions() {
+        List<TxToken> txTokens = new PolygonScanApi().account().txsNftToken(RANDOM_ACCOUNT_1);
+        assertFalse(txTokens.isEmpty());
+    }
+
+    @Test
+    public void contracts_abi() {
+        String miMaticAddress = "0xa3fa99a148fa48d14ed51d610c367c61876997f1";
+        Abi abi = new PolygonScanApi().contract().contractAbi(miMaticAddress);
+        assertNotNull(abi);
+        assertTrue(abi.isVerified());
+    }
+}

--- a/src/test/java/io/api/etherscan/account/AccountErc1155TransferTest.java
+++ b/src/test/java/io/api/etherscan/account/AccountErc1155TransferTest.java
@@ -1,0 +1,78 @@
+package io.api.etherscan.account;
+
+import io.api.ApiRunner;
+import io.api.etherscan.error.InvalidAddressException;
+import io.api.etherscan.model.TxErc1155;
+import org.jetbrains.annotations.NotNull;
+import org.junit.Test;
+
+import java.util.List;
+
+public class AccountErc1155TransferTest extends ApiRunner {
+
+    @Test
+    public void correct() {
+        List<TxErc1155> txs = getApi().account().erc1155Transfers("0xE4C8324534C0C6bCA174Cd0F02fAC9889C36bA59");
+        assertNotNull(txs);
+        assertFalse(txs.isEmpty());
+        assertTxs(txs);
+        assertNotEquals(0, txs.get(0).getGasPrice());
+        assertNotEquals(-1, txs.get(0).getNonce());
+
+        assertNotNull(txs.get(0).toString());
+        assertNotEquals(txs.get(0).toString(), txs.get(1).toString());
+
+        assertNotEquals(txs.get(0), txs.get(1));
+        assertNotEquals(txs.get(0).hashCode(), txs.get(1).hashCode());
+
+        assertEquals(txs.get(1), txs.get(1));
+        assertEquals(txs.get(1).hashCode(), txs.get(1).hashCode());
+    }
+
+    @Test
+    public void correctStartBlock() {
+        List<TxErc1155> txs = getApi().account().erc1155Transfers("0xE4C8324534C0C6bCA174Cd0F02fAC9889C36bA59", 14275897);
+        assertNotNull(txs);
+        assertFalse(txs.isEmpty());
+        assertTxs(txs);
+    }
+
+    @Test
+    public void correctStartBlockEndBlock() {
+        List<TxErc1155> txs = getApi().account().erc1155Transfers("0xE4C8324534C0C6bCA174Cd0F02fAC9889C36bA59", 14275897, 15148929);
+        assertNotNull(txs);
+        assertEquals(11, txs.size());
+        assertTxs(txs);
+    }
+
+    @Test(expected = InvalidAddressException.class)
+    public void invalidParamWithError() {
+        getApi().account().erc1155Transfers("0x6ec53A8fBa6358d59B3C4476D82cc60A2B0FaD7");
+    }
+
+    @Test
+    public void correctParamWithEmptyExpectedResult() {
+        List<TxErc1155> txs = getApi().account().erc1155Transfers("0x31ec53A8fBa6358d59B3C4476D82cc60A2B0FaD7");
+        assertNotNull(txs);
+        assertTrue(txs.isEmpty());
+    }
+
+    private void assertTxs(List<TxErc1155> txs) {
+        txs.forEach(this::asserTx);
+    }
+
+    private void asserTx(@NotNull TxErc1155 tx) {
+        assertNotNull(tx.getBlockHash());
+        assertNotNull(tx.getTokenName());
+        assertNotNull(tx.getTokenSymbol());
+        assertNotNull(tx.getFrom());
+        assertNotNull(tx.getTo());
+        assertNotNull(tx.getTimeStamp());
+        assertNotNull(tx.getTokenID());
+        assertNotNull(tx.getTokenValue());
+        assertNotEquals(-1, (tx.getConfirmations()));
+        assertNotNull(tx.getGasUsed());
+        assertNotEquals(-1, tx.getCumulativeGasUsed());
+        assertNotEquals(-1, tx.getTransactionIndex());
+    }
+}

--- a/src/test/java/io/api/etherscan/account/AccountTxRc721TokenTest.java
+++ b/src/test/java/io/api/etherscan/account/AccountTxRc721TokenTest.java
@@ -2,7 +2,7 @@ package io.api.etherscan.account;
 
 import io.api.ApiRunner;
 import io.api.etherscan.error.InvalidAddressException;
-import io.api.etherscan.model.TxToken;
+import io.api.etherscan.model.TxErc721;
 import org.junit.Test;
 
 import java.util.List;
@@ -15,7 +15,7 @@ public class AccountTxRc721TokenTest extends ApiRunner {
 
     @Test
     public void correct() {
-        List<TxToken> txs = getApi().account().txsNftToken("0x1a1ebe0d86f72884c3fd484ae1e796e08f8ffa67");
+        List<TxErc721> txs = getApi().account().erc721Transfers("0x1a1ebe0d86f72884c3fd484ae1e796e08f8ffa67");
         assertNotNull(txs);
         assertEquals(16, txs.size());
         assertTxs(txs);
@@ -34,8 +34,7 @@ public class AccountTxRc721TokenTest extends ApiRunner {
 
     @Test
     public void correctStartBlock() {
-        List<TxToken> txs = getApi().account().txsNftToken("0x1a1ebe0d86f72884c3fd484ae1e796e08f8ffa67", 4762071);
-        System.out.println(txs);
+        List<TxErc721> txs = getApi().account().erc721Transfers("0x1a1ebe0d86f72884c3fd484ae1e796e08f8ffa67", 4762071);
         assertNotNull(txs);
         assertEquals(5, txs.size());
         assertTxs(txs);
@@ -43,8 +42,7 @@ public class AccountTxRc721TokenTest extends ApiRunner {
 
     @Test
     public void correctStartBlockEndBlock() {
-        List<TxToken> txs = getApi().account().txsNftToken("0x1a1ebe0d86f72884c3fd484ae1e796e08f8ffa67", 4761862, 4761934);
-        System.out.println(txs);
+        List<TxErc721> txs = getApi().account().erc721Transfers("0x1a1ebe0d86f72884c3fd484ae1e796e08f8ffa67", 4761862, 4761934);
         assertNotNull(txs);
         assertEquals(11, txs.size());
         assertTxs(txs);
@@ -52,18 +50,18 @@ public class AccountTxRc721TokenTest extends ApiRunner {
 
     @Test(expected = InvalidAddressException.class)
     public void invalidParamWithError() {
-        getApi().account().txsNftToken("0x6ec53A8fBa6358d59B3C4476D82cc60A2B0FaD7");
+        getApi().account().erc721Transfers("0x6ec53A8fBa6358d59B3C4476D82cc60A2B0FaD7");
     }
 
     @Test
     public void correctParamWithEmptyExpectedResult() {
-        List<TxToken> txs = getApi().account().txsNftToken("0x31ec53A8fBa6358d59B3C4476D82cc60A2B0FaD7");
+        List<TxErc721> txs = getApi().account().erc721Transfers("0x31ec53A8fBa6358d59B3C4476D82cc60A2B0FaD7");
         assertNotNull(txs);
         assertTrue(txs.isEmpty());
     }
 
-    private void assertTxs(List<TxToken> txs) {
-        for (TxToken tx : txs) {
+    private void assertTxs(List<TxErc721> txs) {
+        for (TxErc721 tx : txs) {
             assertNotNull(tx.getBlockHash());
             assertNotNull(tx.getTokenName());
             assertNotNull(tx.getTokenSymbol());

--- a/src/test/java/io/api/etherscan/account/AccountTxTokenTest.java
+++ b/src/test/java/io/api/etherscan/account/AccountTxTokenTest.java
@@ -2,7 +2,7 @@ package io.api.etherscan.account;
 
 import io.api.ApiRunner;
 import io.api.etherscan.error.InvalidAddressException;
-import io.api.etherscan.model.TxToken;
+import io.api.etherscan.model.TxErc20;
 import org.junit.Test;
 
 import java.util.List;
@@ -17,7 +17,7 @@ public class AccountTxTokenTest extends ApiRunner {
 
     @Test
     public void correct() {
-        List<TxToken> txs = getApi().account().txsToken("0xE376F69ED2218076682e2b3B7b9099eC50aD68c4");
+        List<TxErc20> txs = getApi().account().erc20Transfers("0xE376F69ED2218076682e2b3B7b9099eC50aD68c4");
         assertNotNull(txs);
         assertEquals(3, txs.size());
         assertTxs(txs);
@@ -36,7 +36,7 @@ public class AccountTxTokenTest extends ApiRunner {
 
     @Test
     public void correctStartBlock() {
-        List<TxToken> txs = getApi().account().txsToken("0x36ec53A8fBa6358d59B3C4476D82cc60A2B0FaD7", 5578167);
+        List<TxErc20> txs = getApi().account().erc20Transfers("0x36ec53A8fBa6358d59B3C4476D82cc60A2B0FaD7", 5578167);
         assertNotNull(txs);
         assertEquals(11, txs.size());
         assertTxs(txs);
@@ -44,7 +44,7 @@ public class AccountTxTokenTest extends ApiRunner {
 
     @Test
     public void correctStartBlockEndBlock() {
-        List<TxToken> txs = getApi().account().txsToken("0x36ec53A8fBa6358d59B3C4476D82cc60A2B0FaD7", 5578167, 5813576);
+        List<TxErc20> txs = getApi().account().erc20Transfers("0x36ec53A8fBa6358d59B3C4476D82cc60A2B0FaD7", 5578167, 5813576);
         assertNotNull(txs);
         assertEquals(5, txs.size());
         assertTxs(txs);
@@ -52,18 +52,18 @@ public class AccountTxTokenTest extends ApiRunner {
 
     @Test(expected = InvalidAddressException.class)
     public void invalidParamWithError() {
-        getApi().account().txsToken("0x6ec53A8fBa6358d59B3C4476D82cc60A2B0FaD7");
+        getApi().account().erc20Transfers("0x6ec53A8fBa6358d59B3C4476D82cc60A2B0FaD7");
     }
 
     @Test
     public void correctParamWithEmptyExpectedResult() {
-        List<TxToken> txs = getApi().account().txsToken("0x31ec53A8fBa6358d59B3C4476D82cc60A2B0FaD7");
+        List<TxErc20> txs = getApi().account().erc20Transfers("0x31ec53A8fBa6358d59B3C4476D82cc60A2B0FaD7");
         assertNotNull(txs);
         assertTrue(txs.isEmpty());
     }
 
-    private void assertTxs(List<TxToken> txs) {
-        for (TxToken tx : txs) {
+    private void assertTxs(List<TxErc20> txs) {
+        for (TxErc20 tx : txs) {
             assertNotNull(tx.getBlockHash());
             assertNotNull(tx.getTokenName());
             assertNotNull(tx.getTokenSymbol());

--- a/src/test/java/io/api/etherscan/logs/LogApiTest.java
+++ b/src/test/java/io/api/etherscan/logs/LogApiTest.java
@@ -1,0 +1,316 @@
+package io.api.etherscan.logs;
+
+import io.api.etherscan.core.impl.EtherScanApi;
+import io.api.etherscan.model.Log;
+import io.api.etherscan.model.query.LogOp;
+import io.api.etherscan.model.query.LogTopic;
+import io.api.etherscan.model.query.impl.LogQuery;
+import io.api.etherscan.model.query.impl.LogQueryBuilder;
+import io.api.etherscan.model.query.impl.topic.*;
+import io.api.etherscan.model.query.impl.topic.operator.*;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.List;
+
+public class LogApiTest extends Assert {
+
+    public static final String AAVE_ADDRESS = "0x7937d4799803fbbe595ed57278bc4ca21f3bffcb";
+    public static final String AAVE_WITHDRAW_HEX = "0x3115d1449a7b732c986cba18244e897a450f61e1bb8d589cd2e69e6c8924f9f7";
+    public static final String AAVE_USER_HEX = "0x00000000000000000000000073f984d645eea2fe33737d70ce3d637972fe246f";
+    public static final String RESERVE_HEX = "0x000000000000000000000000dac17f958d2ee523a2206206994597c13d831ec7";
+    private static final String LOOKS_TOKEN_ADDRESS = "0xf4d2888d29d722226fafa5d9b24f9164c092421e";
+    private static final String AGGREGATOR_FEE_SHARING_HEX = "0x0000000000000000000000003ab16af1315dc6c95f83cbf522fecf98d00fd9ba";
+    private static final String LOOKS_TOKEN_DISTRIBUTOR_HEX = "0x000000000000000000000000465a790b428268196865a3ae2648481ad7e0d3b1";
+    private static final String TOKEN_TRANSFER_HEX = "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef";
+    private static final String RANDOM_ADDRESS_HEX = "0x0000000000000000000000000e011f17b0cfed38c4fa470e74136edbb097df1f";
+
+    @Test
+    public void single_topic0() {
+        LogQuery single = LogQueryBuilder.with(LOOKS_TOKEN_ADDRESS, 14514697, 14514697)
+                .topic(TopicParamsFactory.of(createTopicZero(TOKEN_TRANSFER_HEX)))
+                .build();
+
+        List<Log> logs = new EtherScanApi().logs().logs(single);
+        assertNotNull(logs);
+        assertEquals(10, logs.size());
+        logs.forEach(log -> {
+            assertEquals(LOOKS_TOKEN_ADDRESS, log.getAddress());
+            List<String> topics = log.getTopics();
+            assertEquals(3, topics.size());
+            assertEquals(TOKEN_TRANSFER_HEX, topics.get(0));
+        });
+    }
+
+    @Test
+    public void single_topic1() {
+        LogQuery single = LogQueryBuilder.with(LOOKS_TOKEN_ADDRESS, 14514697, 14514697)
+                .topic(TopicParamsFactory.of(createTopicOne(RANDOM_ADDRESS_HEX)))
+                .build();
+
+        List<Log> logs = new EtherScanApi().logs().logs(single);
+        assertNotNull(logs);
+        assertEquals(2, logs.size());
+        logs.forEach(log -> {
+            assertEquals(LOOKS_TOKEN_ADDRESS, log.getAddress());
+            List<String> topics = log.getTopics();
+            assertEquals(3, topics.size());
+            assertEquals(RANDOM_ADDRESS_HEX, topics.get(1));
+        });
+    }
+
+    @Test
+    public void single_topic2() {
+        LogQuery single = LogQueryBuilder.with(LOOKS_TOKEN_ADDRESS, 14514697, 14514697)
+                .topic(TopicParamsFactory.of(createTopicTwo(LOOKS_TOKEN_DISTRIBUTOR_HEX)))
+                .build();
+
+        List<Log> logs = new EtherScanApi().logs().logs(single);
+        assertNotNull(logs);
+        assertEquals(5, logs.size());
+        logs.forEach(log -> {
+            assertEquals(LOOKS_TOKEN_ADDRESS, log.getAddress());
+            List<String> topics = log.getTopics();
+            assertEquals(3, topics.size());
+            assertEquals(LOOKS_TOKEN_DISTRIBUTOR_HEX, topics.get(2));
+        });
+    }
+
+    @Test
+    public void single_topic3() {
+        LogQuery single = LogQueryBuilder.with(AAVE_ADDRESS, 14514529, 14514529)
+                .topic(TopicParamsFactory.of(createTopicThree(AAVE_USER_HEX)))
+                .build();
+
+        List<Log> logs = new EtherScanApi().logs().logs(single);
+        assertNotNull(logs);
+        assertEquals(1, logs.size());
+        logs.forEach(log -> {
+            assertEquals(AAVE_ADDRESS, log.getAddress());
+            List<String> topics = log.getTopics();
+            assertEquals(4, topics.size());
+            assertEquals(AAVE_USER_HEX, topics.get(3));
+        });
+    }
+
+    @Test
+    public void pair_topic0And1() {
+        LogQuery pair = LogQueryBuilder.with(LOOKS_TOKEN_ADDRESS, 14514697, 14514697)
+                .topic(TopicParamsFactory.of(
+                        createTopicZero(TOKEN_TRANSFER_HEX),
+                        createTopicOne(RANDOM_ADDRESS_HEX),
+                        new LogOperatorZeroOne(LogOp.AND)))
+                .build();
+
+        List<Log> logs = new EtherScanApi().logs().logs(pair);
+        assertNotNull(logs);
+        assertEquals(1, logs.size());
+        logs.forEach(log -> {
+            assertEquals(LOOKS_TOKEN_ADDRESS, log.getAddress());
+            List<String> topics = log.getTopics();
+            assertEquals(3, topics.size());
+            assertEquals(TOKEN_TRANSFER_HEX, topics.get(0));
+            assertEquals(RANDOM_ADDRESS_HEX, topics.get(1));
+        });
+    }
+
+    @Test
+    public void pair_topic0And2() {
+        LogQuery pair = LogQueryBuilder.with(LOOKS_TOKEN_ADDRESS, 14514697, 14514697)
+                .topic(TopicParamsFactory.of(
+                        createTopicZero(TOKEN_TRANSFER_HEX),
+                        createTopicTwo(LOOKS_TOKEN_DISTRIBUTOR_HEX),
+                        new LogOperatorZeroTwo(LogOp.AND)))
+                .build();
+
+        List<Log> logs = new EtherScanApi().logs().logs(pair);
+        assertNotNull(logs);
+        assertEquals(3, logs.size());
+        logs.forEach(log -> {
+            assertEquals(LOOKS_TOKEN_ADDRESS, log.getAddress());
+            List<String> topics = log.getTopics();
+            assertEquals(3, topics.size());
+            assertEquals(TOKEN_TRANSFER_HEX, topics.get(0));
+            assertEquals(LOOKS_TOKEN_DISTRIBUTOR_HEX, topics.get(2));
+        });
+    }
+
+    @Test
+    public void pair_topic0And3() {
+        LogQuery pair = LogQueryBuilder.with(AAVE_ADDRESS, 14514529, 14514529)
+                .topic(TopicParamsFactory.of(createTopicZero(AAVE_WITHDRAW_HEX),
+                        createTopicThree(AAVE_USER_HEX),
+                        new LogOperatorZeroThree(LogOp.AND)))
+                .build();
+
+        List<Log> logs = new EtherScanApi().logs().logs(pair);
+        assertNotNull(logs);
+        assertEquals(1, logs.size());
+        logs.forEach(log -> {
+            assertEquals(AAVE_ADDRESS, log.getAddress());
+            List<String> topics = log.getTopics();
+            assertEquals(4, topics.size());
+            assertEquals(AAVE_WITHDRAW_HEX, topics.get(0));
+            assertEquals(AAVE_USER_HEX, topics.get(3));
+        });
+    }
+
+    @Test
+    public void pair_topic1And3() {
+        LogQuery pair = LogQueryBuilder.with(AAVE_ADDRESS, 14514529, 14514529)
+                .topic(TopicParamsFactory.of(createTopicOne(RESERVE_HEX),
+                        createTopicThree(AAVE_USER_HEX),
+                        new LogOperatorOneThree(LogOp.AND)))
+                .build();
+
+        List<Log> logs = new EtherScanApi().logs().logs(pair);
+        assertNotNull(logs);
+        assertEquals(1, logs.size());
+        logs.forEach(log -> {
+            assertEquals(AAVE_ADDRESS, log.getAddress());
+            List<String> topics = log.getTopics();
+            assertEquals(4, topics.size());
+            assertEquals(RESERVE_HEX, topics.get(1));
+            assertEquals(AAVE_USER_HEX, topics.get(2));
+            assertEquals(AAVE_USER_HEX, topics.get(3));
+        });
+    }
+
+    @Test
+    public void pair_topic2And3() {
+        LogQuery quadruple = LogQueryBuilder.with(AAVE_ADDRESS, 14514529, 14514529)
+                .topic(TopicParamsFactory.of(createTopicTwo(AAVE_USER_HEX),
+                        createTopicThree(AAVE_USER_HEX),
+                        new LogOperatorTwoThree(LogOp.AND)))
+                .build();
+
+        List<Log> logs = new EtherScanApi().logs().logs(quadruple);
+        assertNotNull(logs);
+        assertEquals(1, logs.size());
+        logs.forEach(log -> {
+            assertEquals(AAVE_ADDRESS, log.getAddress());
+            List<String> topics = log.getTopics();
+            assertEquals(4, topics.size());
+            assertEquals(AAVE_USER_HEX, topics.get(2));
+            assertEquals(AAVE_USER_HEX, topics.get(3));
+        });
+    }
+
+    @Test
+    public void triple_topic0And1And2() {
+        LogQuery triple = LogQueryBuilder.with(LOOKS_TOKEN_ADDRESS, 14514697, 14514697)
+                .topic(TopicParamsFactory.of(
+                        createTopicZero(TOKEN_TRANSFER_HEX),
+                        createTopicOne(RANDOM_ADDRESS_HEX),
+                        createTopicTwo(AGGREGATOR_FEE_SHARING_HEX),
+                        new LogOperatorZeroOne(LogOp.AND),
+                        new LogOperatorZeroTwo(LogOp.AND),
+                        new LogOperatorOneTwo(LogOp.AND)))
+                .build();
+
+        List<Log> logs = new EtherScanApi().logs().logs(triple);
+        assertNotNull(logs);
+        assertEquals(1, logs.size());
+        logs.forEach(log -> {
+            assertEquals(LOOKS_TOKEN_ADDRESS, log.getAddress());
+            List<String> topics = log.getTopics();
+            assertEquals(3, topics.size());
+            assertEquals(TOKEN_TRANSFER_HEX, topics.get(0));
+            assertEquals(RANDOM_ADDRESS_HEX, topics.get(1));
+            assertEquals(AGGREGATOR_FEE_SHARING_HEX, topics.get(2));
+        });
+    }
+
+    @Test
+    public void triple_topic0And1And3() {
+        LogQuery triple = LogQueryBuilder.with(AAVE_ADDRESS, 14514529, 14514529)
+                .topic(TopicParamsFactory.of(createTopicZero(AAVE_WITHDRAW_HEX),
+                        createTopicOne(RESERVE_HEX),
+                        createTopicThree(AAVE_USER_HEX),
+                        new LogOperatorZeroOne(LogOp.AND),
+                        new LogOperatorZeroThree(LogOp.AND),
+                        new LogOperatorOneThree(LogOp.AND)))
+                .build();
+
+        List<Log> logs = new EtherScanApi().logs().logs(triple);
+        assertNotNull(logs);
+        assertEquals(1, logs.size());
+        logs.forEach(log -> {
+            assertEquals(AAVE_ADDRESS, log.getAddress());
+            List<String> topics = log.getTopics();
+            assertEquals(4, topics.size());
+            assertEquals(AAVE_WITHDRAW_HEX, topics.get(0));
+            assertEquals(RESERVE_HEX, topics.get(1));
+            assertEquals(AAVE_USER_HEX, topics.get(3));
+        });
+    }
+
+    @Test
+    public void triple_topic1And2And3() {
+        LogQuery triple = LogQueryBuilder.with(AAVE_ADDRESS, 14514529, 14514529)
+                .topic(TopicParamsFactory.of(createTopicOne(RESERVE_HEX),
+                        createTopicTwo(AAVE_USER_HEX),
+                        createTopicThree(AAVE_USER_HEX),
+                        new LogOperatorOneTwo(LogOp.AND),
+                        new LogOperatorOneThree(LogOp.AND),
+                        new LogOperatorTwoThree(LogOp.AND)))
+                .build();
+
+        List<Log> logs = new EtherScanApi().logs().logs(triple);
+        assertNotNull(logs);
+        assertEquals(1, logs.size());
+        logs.forEach(log -> {
+            assertEquals(AAVE_ADDRESS, log.getAddress());
+            List<String> topics = log.getTopics();
+            assertEquals(4, topics.size());
+            assertEquals(RESERVE_HEX, topics.get(1));
+            assertEquals(AAVE_USER_HEX, topics.get(2));
+            assertEquals(AAVE_USER_HEX, topics.get(3));
+        });
+    }
+
+    @Test
+    public void quadruple() {
+        LogQuery quadruple = LogQueryBuilder.with(AAVE_ADDRESS, 14514529, 14514529)
+                .topic(TopicParamsFactory.of(createTopicZero(AAVE_WITHDRAW_HEX),
+                        createTopicOne(RESERVE_HEX),
+                        createTopicTwo(AAVE_USER_HEX),
+                        createTopicThree(AAVE_USER_HEX),
+                        new LogOperatorZeroOne(LogOp.AND),
+                        new LogOperatorZeroTwo(LogOp.AND),
+                        new LogOperatorZeroThree(LogOp.AND),
+                        new LogOperatorOneTwo(LogOp.AND),
+                        new LogOperatorOneThree(LogOp.AND),
+                        new LogOperatorTwoThree(LogOp.AND)))
+                .build();
+
+        List<Log> logs = new EtherScanApi().logs().logs(quadruple);
+        assertNotNull(logs);
+        assertEquals(1, logs.size());
+        logs.forEach(log -> {
+            assertEquals(AAVE_ADDRESS, log.getAddress());
+            List<String> topics = log.getTopics();
+            assertEquals(4, topics.size());
+            assertEquals(AAVE_WITHDRAW_HEX, topics.get(0));
+            assertEquals(RESERVE_HEX, topics.get(1));
+            assertEquals(AAVE_USER_HEX, topics.get(2));
+            assertEquals(AAVE_USER_HEX, topics.get(3));
+        });
+    }
+
+    private TopicZero createTopicZero(String hex) {
+        return new TopicZero(LogTopic.of(hex));
+    }
+
+    private TopicOne createTopicOne(String hex) {
+        return new TopicOne(LogTopic.of(hex));
+    }
+
+    private TopicTwo createTopicTwo(String hex) {
+        return new TopicTwo(LogTopic.of(hex));
+    }
+
+    private TopicThree createTopicThree(String hex) {
+        return new TopicThree(LogTopic.of(hex));
+    }
+}

--- a/src/test/java/io/api/etherscan/logs/LogQueryBuilderTest.java
+++ b/src/test/java/io/api/etherscan/logs/LogQueryBuilderTest.java
@@ -2,11 +2,12 @@ package io.api.etherscan.logs;
 
 import io.api.ApiRunner;
 import io.api.etherscan.error.InvalidAddressException;
-import io.api.etherscan.error.LogQueryException;
 import io.api.etherscan.model.query.LogOp;
+import io.api.etherscan.model.query.LogTopic;
 import io.api.etherscan.model.query.impl.LogQuery;
 import io.api.etherscan.model.query.impl.LogQueryBuilder;
-import io.api.etherscan.model.query.impl.LogTopicQuadro;
+import io.api.etherscan.model.query.impl.topic.*;
+import io.api.etherscan.model.query.impl.topic.operator.*;
 import org.junit.Test;
 
 /**
@@ -17,339 +18,340 @@ import org.junit.Test;
  */
 public class LogQueryBuilderTest extends ApiRunner {
 
-    @Test
-    public void singleCorrect() {
-        LogQuery single = LogQueryBuilder.with("0x33990122638b9132ca29c723bdf037f1a891a70c")
-                .topic("0xf63780e752c6a54a94fc52715dbc5518a3b4c3c2833d301a204226548a2a8545")
-                .build();
-
-        assertNotNull(single);
-        assertNotNull(single.getParams());
-    }
-
     @Test(expected = InvalidAddressException.class)
-    public void singleInCorrectAddress() {
-        LogQuery single = LogQueryBuilder.with("033990122638b9132ca29c723bdf037f1a891a70c")
-                .topic("0xf63780e752c6a54a94fc52715dbc5518a3b4c3c2833d301a204226548a2a8545")
+    public void inCorrectAddress() {
+        LogQueryBuilder.with("033990122638b9132ca29c723bdf037f1a891a70c")
                 .build();
-
-        assertNotNull(single);
-        assertNotNull(single.getParams());
     }
 
-    @Test(expected = LogQueryException.class)
-    public void singleInCorrectTopic() {
+    @Test
+    public void standard() {
+        LogQuery standard = LogQueryBuilder.with("0x33990122638b9132ca29c723bdf037f1a891a70c", 69L, 420L)
+                .build();
+
+        assertNotNull(standard);
+        assertNotNull(standard.getParams());
+        assertEquals("&address=0x33990122638b9132ca29c723bdf037f1a891a70c"
+                + "&fromBlock=69"
+                + "&toBlock=420", standard.getParams());
+    }
+
+    @Test
+    public void single_topic0() {
         LogQuery single = LogQueryBuilder.with("0x33990122638b9132ca29c723bdf037f1a891a70c")
-                .topic("6516=")
+                .topic(TopicParamsFactory.of(createTopicZero("0xf63780e752c6a54a94fc52715dbc5518a3b4c3c2833d301a204226548a2a8545")))
                 .build();
 
         assertNotNull(single);
         assertNotNull(single.getParams());
+        assertEquals("&address=0x33990122638b9132ca29c723bdf037f1a891a70c"
+                + "&fromBlock=0"
+                + "&toBlock=99999999999"
+                + "&topic0=0xf63780e752c6a54a94fc52715dbc5518a3b4c3c2833d301a204226548a2a8545", single.getParams());
     }
 
     @Test
-    public void tupleCorrect() {
-        LogQuery tuple = LogQueryBuilder.with("0x33990122638b9132ca29c723bdf037f1a891a70c", 379224)
-                .topic("0xf63780e752c6a54a94fc52715dbc5518a3b4c3c2833d301a204226548a2a8545",
-                        "0x72657075746174696f6e00000000000000000000000000000000000000000000")
-                .setOpTopic0_1(LogOp.AND)
+    public void single_topic1() {
+        LogQuery single = LogQueryBuilder.with("0x33990122638b9132ca29c723bdf037f1a891a70c")
+                .topic(TopicParamsFactory.of(createTopicOne("0xf63780e752c6a54a94fc52715dbc5518a3b4c3c2833d301a204226548a2a8545")))
                 .build();
 
-        assertNotNull(tuple);
-        assertNotNull(tuple.getParams());
-    }
-
-    @Test(expected = LogQueryException.class)
-    public void tupleInCorrectOp() {
-        LogQuery tuple = LogQueryBuilder.with("0x33990122638b9132ca29c723bdf037f1a891a70c", 379224)
-                .topic("0xf63780e752c6a54a94fc52715dbc5518a3b4c3c2833d301a204226548a2a8545",
-                        "0x72657075746174696f6e00000000000000000000000000000000000000000000")
-                .setOpTopic0_1(null)
-                .build();
-
-        assertNotNull(tuple);
-        assertNotNull(tuple.getParams());
+        assertNotNull(single);
+        assertNotNull(single.getParams());
+        assertEquals("&address=0x33990122638b9132ca29c723bdf037f1a891a70c"
+                + "&fromBlock=0"
+                + "&toBlock=99999999999"
+                + "&topic1=0xf63780e752c6a54a94fc52715dbc5518a3b4c3c2833d301a204226548a2a8545", single.getParams());
     }
 
     @Test
-    public void tripleCorrect() {
-        LogQuery triple = LogQueryBuilder.with("0x33990122638b9132ca29c723bdf037f1a891a70c", 379224, 400000)
-                .topic("0xf63780e752c6a54a94fc52715dbc5518a3b4c3c2833d301a204226548a2a8545",
-                        "0x72657075746174696f6e00000000000000000000000000000000000000000000",
-                        "0x72657075746174696f6e00000000000000000000000000000000000000000000")
-                .setOpTopic0_1(LogOp.AND)
-                .setOpTopic0_2(LogOp.OR)
-                .setOpTopic1_2(LogOp.AND)
+    public void single_topic2() {
+        LogQuery single = LogQueryBuilder.with("0x33990122638b9132ca29c723bdf037f1a891a70c")
+                .topic(TopicParamsFactory.of(createTopicTwo("0xf63780e752c6a54a94fc52715dbc5518a3b4c3c2833d301a204226548a2a8545")))
                 .build();
 
-        assertNotNull(triple);
-        assertNotNull(triple.getParams());
-    }
-
-    @Test(expected = LogQueryException.class)
-    public void tripleInCorrectOp() {
-        LogQuery triple = LogQueryBuilder.with("0x33990122638b9132ca29c723bdf037f1a891a70c", 379224, 400000)
-                .topic("0xf63780e752c6a54a94fc52715dbc5518a3b4c3c2833d301a204226548a2a8545",
-                        "0x72657075746174696f6e00000000000000000000000000000000000000000000",
-                        "0x72657075746174696f6e00000000000000000000000000000000000000000000")
-                .setOpTopic0_1(LogOp.AND)
-                .setOpTopic0_2(null)
-                .setOpTopic1_2(LogOp.AND)
-                .build();
-
-        assertNotNull(triple);
-        assertNotNull(triple.getParams());
-    }
-
-    @Test(expected = LogQueryException.class)
-    public void tripleInCorrectTopic1() {
-        LogQuery triple = LogQueryBuilder.with("0x33990122638b9132ca29c723bdf037f1a891a70c", 379224, 400000)
-                .topic(null,
-                        "0x72657075746174696f6e00000000000000000000000000000000000000000000",
-                        "0x72657075746174696f6e00000000000000000000000000000000000000000000")
-                .setOpTopic0_1(LogOp.AND)
-                .setOpTopic0_2(LogOp.AND)
-                .setOpTopic1_2(LogOp.AND)
-                .build();
-
-        assertNotNull(triple);
-        assertNotNull(triple.getParams());
-    }
-
-    @Test(expected = LogQueryException.class)
-    public void tripleInCorrectTopic2() {
-        LogQuery triple = LogQueryBuilder.with("0x33990122638b9132ca29c723bdf037f1a891a70c", 379224, 400000)
-                .topic("0xf63780e752c6a54a94fc52715dbc5518a3b4c3c2833d301a204226548a2a8545",
-                        null,
-                        "0x72657075746174696f6e00000000000000000000000000000000000000000000")
-                .setOpTopic0_1(LogOp.AND)
-                .setOpTopic0_2(LogOp.AND)
-                .setOpTopic1_2(LogOp.AND)
-                .build();
-
-        assertNotNull(triple);
-        assertNotNull(triple.getParams());
-    }
-
-    @Test(expected = LogQueryException.class)
-    public void tripleInCorrectTopic3() {
-        LogQuery triple = LogQueryBuilder.with("0x33990122638b9132ca29c723bdf037f1a891a70c", 379224, 400000)
-                .topic("0xf63780e752c6a54a94fc52715dbc5518a3b4c3c2833d301a204226548a2a8545",
-                        "0x72657075746174696f6e00000000000000000000000000000000000000000000",
-                        null)
-                .setOpTopic0_1(LogOp.AND)
-                .setOpTopic0_2(LogOp.AND)
-                .setOpTopic1_2(LogOp.AND)
-                .build();
-
-        assertNotNull(triple);
-        assertNotNull(triple.getParams());
+        assertNotNull(single);
+        assertNotNull(single.getParams());
+        assertEquals("&address=0x33990122638b9132ca29c723bdf037f1a891a70c"
+                + "&fromBlock=0"
+                + "&toBlock=99999999999"
+                + "&topic2=0xf63780e752c6a54a94fc52715dbc5518a3b4c3c2833d301a204226548a2a8545", single.getParams());
     }
 
     @Test
-    public void quadroCorrect() {
-        LogQuery quadro = LogQueryBuilder.with("0x33990122638b9132ca29c723bdf037f1a891a70c")
-                .topic("0xf63780e752c6a54a94fc52715dbc5518a3b4c3c2833d301a204226548a2a8545",
-                        "0x72657075746174696f6e00000000000000000000000000000000000000000000",
-                        "0x72657075746174696f6e00000000000000000000000000000000000000000000",
-                        "0x72657075746174696f6e00000000000000000000000000000000000000000000")
-                .setOpTopic0_1(LogOp.AND)
-                .setOpTopic0_2(LogOp.OR)
-                .setOpTopic0_3(LogOp.AND)
-                .setOpTopic1_2(LogOp.OR)
-                .setOpTopic1_3(LogOp.OR)
-                .setOpTopic2_3(LogOp.OR)
+    public void single_topic3() {
+        LogQuery single = LogQueryBuilder.with("0x33990122638b9132ca29c723bdf037f1a891a70c")
+                .topic(TopicParamsFactory.of(createTopicThree("0xf63780e752c6a54a94fc52715dbc5518a3b4c3c2833d301a204226548a2a8545")))
                 .build();
 
-        assertNotNull(quadro);
-        assertNotNull(quadro.getParams());
+        assertNotNull(single);
+        assertNotNull(single.getParams());
+        assertEquals("&address=0x33990122638b9132ca29c723bdf037f1a891a70c"
+                + "&fromBlock=0"
+                + "&toBlock=99999999999"
+                + "&topic3=0xf63780e752c6a54a94fc52715dbc5518a3b4c3c2833d301a204226548a2a8545", single.getParams());
     }
 
-    @Test(expected = LogQueryException.class)
-    public void quadroIncorrectTopic2() {
-        LogQuery quadro = LogQueryBuilder.with("0x33990122638b9132ca29c723bdf037f1a891a70c")
-                .topic("0xf63780e752c6a54a94fc52715dbc5518a3b4c3c2833d301a204226548a2a8545",
-                        null,
-                        "0x72657075746174696f6e00000000000000000000000000000000000000000000",
-                        "0x72657075746174696f6e00000000000000000000000000000000000000000000")
-                .setOpTopic0_1(LogOp.AND)
-                .setOpTopic0_2(LogOp.OR)
-                .setOpTopic0_3(LogOp.AND)
-                .setOpTopic1_2(LogOp.OR)
-                .setOpTopic1_3(LogOp.OR)
-                .setOpTopic2_3(LogOp.OR)
+    @Test
+    public void pair_zeroOne() {
+        LogQuery pair = LogQueryBuilder.with("0x33990122638b9132ca29c723bdf037f1a891a70c", 379224)
+                .topic(TopicParamsFactory.of(
+                        createTopicZero("0xf63780e752c6a54a94fc52715dbc5518a3b4c3c2833d301a204226548a2a8545"),
+                        createTopicOne("0x72657075746174696f6e00000000000000000000000000000000000000000000"),
+                        new LogOperatorZeroOne(LogOp.AND)))
                 .build();
 
-        assertNotNull(quadro);
-        assertNotNull(quadro.getParams());
+        assertNotNull(pair);
+        assertNotNull(pair.getParams());
+        assertEquals("&address=0x33990122638b9132ca29c723bdf037f1a891a70c"
+                + "&fromBlock=379224"
+                + "&toBlock=99999999999"
+                + "&topic0=0xf63780e752c6a54a94fc52715dbc5518a3b4c3c2833d301a204226548a2a8545"
+                + "&topic1=0x72657075746174696f6e00000000000000000000000000000000000000000000"
+                + "&topic0_1_opr=and", pair.getParams());
     }
 
-    @Test(expected = LogQueryException.class)
-    public void tupleIncorrectTopic2() {
-        LogQuery quadro = LogQueryBuilder.with("0x33990122638b9132ca29c723bdf037f1a891a70c")
-                .topic("0xf63780e752c6a54a94fc52715dbc5518a3b4c3c2833d301a204226548a2a8545",
-                        null)
-                .setOpTopic0_1(LogOp.AND)
+    @Test
+    public void pair_zeroTwo() {
+        LogQuery pair = LogQueryBuilder.with("0x33990122638b9132ca29c723bdf037f1a891a70c", 379224)
+                .topic(TopicParamsFactory.of(
+                        createTopicZero("0xf63780e752c6a54a94fc52715dbc5518a3b4c3c2833d301a204226548a2a8545"),
+                        createTopicTwo("0x72657075746174696f6e00000000000000000000000000000000000000000000"),
+                        new LogOperatorZeroTwo(LogOp.OR)))
                 .build();
 
-        assertNotNull(quadro);
-        assertNotNull(quadro.getParams());
+        assertNotNull(pair);
+        assertNotNull(pair.getParams());
+        assertEquals("&address=0x33990122638b9132ca29c723bdf037f1a891a70c"
+                + "&fromBlock=379224"
+                + "&toBlock=99999999999"
+                + "&topic0=0xf63780e752c6a54a94fc52715dbc5518a3b4c3c2833d301a204226548a2a8545"
+                + "&topic2=0x72657075746174696f6e00000000000000000000000000000000000000000000"
+                + "&topic0_2_opr=or", pair.getParams());
     }
 
-    @Test(expected = LogQueryException.class)
-    public void tupleIncorrectTopic1() {
-        LogQuery quadro = LogQueryBuilder.with("0x33990122638b9132ca29c723bdf037f1a891a70c")
-                .topic(null,
-                        "0xf63780e752c6a54a94fc52715dbc5518a3b4c3c2833d301a204226548a2a8545")
-                .setOpTopic0_1(LogOp.AND)
+    @Test
+    public void pair_zeroThree() {
+        LogQuery pair = LogQueryBuilder.with("0x33990122638b9132ca29c723bdf037f1a891a70c", 379224)
+                .topic(TopicParamsFactory.of(
+                        createTopicZero("0xf63780e752c6a54a94fc52715dbc5518a3b4c3c2833d301a204226548a2a8545"),
+                        createTopicThree("0x72657075746174696f6e00000000000000000000000000000000000000000000"),
+                        new LogOperatorZeroThree(LogOp.OR)))
                 .build();
 
-        assertNotNull(quadro);
-        assertNotNull(quadro.getParams());
+        assertNotNull(pair);
+        assertNotNull(pair.getParams());
+        assertEquals("&address=0x33990122638b9132ca29c723bdf037f1a891a70c"
+                + "&fromBlock=379224"
+                + "&toBlock=99999999999"
+                + "&topic0=0xf63780e752c6a54a94fc52715dbc5518a3b4c3c2833d301a204226548a2a8545"
+                + "&topic3=0x72657075746174696f6e00000000000000000000000000000000000000000000"
+                + "&topic0_3_opr=or", pair.getParams());
     }
 
-    @Test(expected = LogQueryException.class)
-    public void quadroIncorrectOp1() {
-        LogTopicQuadro topicQuadro = LogQueryBuilder.with("0x33990122638b9132ca29c723bdf037f1a891a70c")
-                .topic("0xf63780e752c6a54a94fc52715dbc5518a3b4c3c2833d301a204226548a2a8545",
-                        "0xf63780e752c6a54a94fc52715dbc5518a3b4c3c2833d301a204226548a2a8545",
-                        "0x72657075746174696f6e00000000000000000000000000000000000000000000",
-                        "0x72657075746174696f6e00000000000000000000000000000000000000000000");
-
-        topicQuadro
-                .setOpTopic0_1(null)
-                .setOpTopic0_2(LogOp.OR)
-                .setOpTopic0_3(LogOp.AND)
-                .setOpTopic1_2(LogOp.OR)
-                .setOpTopic1_3(LogOp.OR)
-                .setOpTopic2_3(LogOp.OR)
+    @Test
+    public void pair_oneTwo() {
+        LogQuery pair = LogQueryBuilder.with("0x33990122638b9132ca29c723bdf037f1a891a70c", 379224)
+                .topic(TopicParamsFactory.of(
+                        createTopicOne("0xf63780e752c6a54a94fc52715dbc5518a3b4c3c2833d301a204226548a2a8545"),
+                        createTopicTwo("0x72657075746174696f6e00000000000000000000000000000000000000000000"),
+                        new LogOperatorOneTwo(LogOp.AND)))
                 .build();
+
+        assertNotNull(pair);
+        assertNotNull(pair.getParams());
+        assertEquals("&address=0x33990122638b9132ca29c723bdf037f1a891a70c"
+                + "&fromBlock=379224"
+                + "&toBlock=99999999999"
+                + "&topic1=0xf63780e752c6a54a94fc52715dbc5518a3b4c3c2833d301a204226548a2a8545"
+                + "&topic2=0x72657075746174696f6e00000000000000000000000000000000000000000000"
+                + "&topic1_2_opr=and", pair.getParams());
     }
 
-    @Test(expected = LogQueryException.class)
-    public void quadroIncorrectOp2() {
-        LogTopicQuadro topicQuadro = LogQueryBuilder.with("0x33990122638b9132ca29c723bdf037f1a891a70c")
-                .topic("0xf63780e752c6a54a94fc52715dbc5518a3b4c3c2833d301a204226548a2a8545",
-                        "0xf63780e752c6a54a94fc52715dbc5518a3b4c3c2833d301a204226548a2a8545",
-                        "0x72657075746174696f6e00000000000000000000000000000000000000000000",
-                        "0x72657075746174696f6e00000000000000000000000000000000000000000000");
-
-        topicQuadro.setOpTopic0_1(LogOp.AND)
-                .setOpTopic0_2(null)
-                .setOpTopic0_3(LogOp.AND)
-                .setOpTopic1_2(LogOp.OR)
-                .setOpTopic1_3(LogOp.OR)
-                .setOpTopic2_3(LogOp.OR)
+    @Test
+    public void pair_oneThree() {
+        LogQuery pair = LogQueryBuilder.with("0x33990122638b9132ca29c723bdf037f1a891a70c", 379224)
+                .topic(TopicParamsFactory.of(
+                        createTopicOne("0xf63780e752c6a54a94fc52715dbc5518a3b4c3c2833d301a204226548a2a8545"),
+                        createTopicThree("0x72657075746174696f6e00000000000000000000000000000000000000000000"),
+                        new LogOperatorOneThree(LogOp.AND)))
                 .build();
+
+        assertNotNull(pair);
+        assertNotNull(pair.getParams());
+        assertEquals("&address=0x33990122638b9132ca29c723bdf037f1a891a70c"
+                + "&fromBlock=379224"
+                + "&toBlock=99999999999"
+                + "&topic1=0xf63780e752c6a54a94fc52715dbc5518a3b4c3c2833d301a204226548a2a8545"
+                + "&topic3=0x72657075746174696f6e00000000000000000000000000000000000000000000"
+                + "&topic1_3_opr=and", pair.getParams());
     }
 
-    @Test(expected = LogQueryException.class)
-    public void quadroIncorrectOp3() {
-        LogTopicQuadro topicQuadro = LogQueryBuilder.with("0x33990122638b9132ca29c723bdf037f1a891a70c")
-                .topic("0xf63780e752c6a54a94fc52715dbc5518a3b4c3c2833d301a204226548a2a8545",
-                        "0xf63780e752c6a54a94fc52715dbc5518a3b4c3c2833d301a204226548a2a8545",
-                        "0x72657075746174696f6e00000000000000000000000000000000000000000000",
-                        "0x72657075746174696f6e00000000000000000000000000000000000000000000");
-
-        topicQuadro
-                .setOpTopic0_1(LogOp.AND)
-                .setOpTopic0_2(LogOp.OR)
-                .setOpTopic0_3(null)
-                .setOpTopic1_2(LogOp.OR)
-                .setOpTopic1_3(LogOp.OR)
-                .setOpTopic2_3(LogOp.OR)
+    @Test
+    public void pair_twoThree() {
+        LogQuery pair = LogQueryBuilder.with("0x33990122638b9132ca29c723bdf037f1a891a70c", 379224)
+                .topic(TopicParamsFactory.of(
+                        createTopicTwo("0xf63780e752c6a54a94fc52715dbc5518a3b4c3c2833d301a204226548a2a8545"),
+                        createTopicThree("0x72657075746174696f6e00000000000000000000000000000000000000000000"),
+                        new LogOperatorTwoThree(LogOp.AND)))
                 .build();
+
+        assertNotNull(pair);
+        assertNotNull(pair.getParams());
+        assertEquals("&address=0x33990122638b9132ca29c723bdf037f1a891a70c"
+                + "&fromBlock=379224"
+                + "&toBlock=99999999999"
+                + "&topic2=0xf63780e752c6a54a94fc52715dbc5518a3b4c3c2833d301a204226548a2a8545"
+                + "&topic3=0x72657075746174696f6e00000000000000000000000000000000000000000000"
+                + "&topic2_3_opr=and", pair.getParams());
     }
 
-    @Test(expected = LogQueryException.class)
-    public void quadroInCorrectAgainTopic() {
-        LogQuery quadro = LogQueryBuilder.with("0x33990122638b9132ca29c723bdf037f1a891a70c")
-                .topic("0xf63780e752c6a54a94fc52715dbc5518a3b4c3c2833d301a204226548a2a8545",
-                        "0x72657075746174696f6e00000000000000000000000000000000000000000000",
-                        "0x72657075746174696f6e00000000000000000000000000000000000000000000",
-                        null)
-                .setOpTopic0_1(LogOp.AND)
-                .setOpTopic0_2(LogOp.OR)
-                .setOpTopic0_3(LogOp.AND)
-                .setOpTopic1_2(LogOp.OR)
-                .setOpTopic1_3(LogOp.OR)
-                .setOpTopic2_3(LogOp.OR)
+    @Test
+    public void triple_zeroOneTwo() {
+        LogQuery triple = LogQueryBuilder.with("0x33990122638b9132ca29c723bdf037f1a891a70c", 379224, 400000)
+                .topic(TopicParamsFactory.of(
+                        createTopicZero("0xf63780e752c6a54a94fc52715dbc5518a3b4c3c2833d301a204226548a2a8545"),
+                        createTopicOne("0x72657075746174696f6e00000000000000000000000000000000000000000000"),
+                        createTopicTwo("0x00000000000000000000000013990122638b9132ca29c723bdf037f1a891a70c"),
+                        new LogOperatorZeroOne(LogOp.AND),
+                        new LogOperatorZeroTwo(LogOp.OR),
+                        new LogOperatorOneTwo(LogOp.OR)))
                 .build();
 
-        assertNotNull(quadro);
-        assertNotNull(quadro.getParams());
+        assertNotNull(triple);
+        assertNotNull(triple.getParams());
+        assertEquals("&address=0x33990122638b9132ca29c723bdf037f1a891a70c"
+                + "&fromBlock=379224"
+                + "&toBlock=400000"
+                + "&topic0=0xf63780e752c6a54a94fc52715dbc5518a3b4c3c2833d301a204226548a2a8545"
+                + "&topic1=0x72657075746174696f6e00000000000000000000000000000000000000000000"
+                + "&topic2=0x00000000000000000000000013990122638b9132ca29c723bdf037f1a891a70c"
+                + "&topic0_1_opr=and"
+                + "&topic0_2_opr=or"
+                + "&topic1_2_opr=or", triple.getParams());
     }
 
-    @Test(expected = LogQueryException.class)
-    public void quadroInCorrectOp4() {
-        LogTopicQuadro topicQuadro = LogQueryBuilder.with("0x33990122638b9132ca29c723bdf037f1a891a70c")
-                .topic("0xf63780e752c6a54a94fc52715dbc5518a3b4c3c2833d301a204226548a2a8545",
-                        "0x72657075746174696f6e00000000000000000000000000000000000000000000",
-                        "0xf63780e752c6a54a94fc52715dbc5518a3b4c3c2833d301a204226548a2a8545",
-                        "0xf63780e752c6a54a94fc52715dbc5518a3b4c3c2833d301a204226548a2a8545");
-
-        topicQuadro
-                .setOpTopic0_1(LogOp.AND)
-                .setOpTopic0_2(LogOp.OR)
-                .setOpTopic0_3(LogOp.AND)
-                .setOpTopic1_2(null)
-                .setOpTopic1_3(LogOp.OR)
-                .setOpTopic2_3(LogOp.OR)
+    @Test
+    public void triple_zeroOneThree() {
+        LogQuery triple = LogQueryBuilder.with("0x33990122638b9132ca29c723bdf037f1a891a70c", 379224, 400000)
+                .topic(TopicParamsFactory.of(
+                        createTopicZero("0xf63780e752c6a54a94fc52715dbc5518a3b4c3c2833d301a204226548a2a8545"),
+                        createTopicOne("0x72657075746174696f6e00000000000000000000000000000000000000000000"),
+                        createTopicThree("0x00000000000000000000000013990122638b9132ca29c723bdf037f1a891a70c"),
+                        new LogOperatorZeroOne(LogOp.AND),
+                        new LogOperatorZeroThree(LogOp.OR),
+                        new LogOperatorOneThree(LogOp.OR)))
                 .build();
+
+        assertNotNull(triple);
+        assertNotNull(triple.getParams());
+        assertEquals("&address=0x33990122638b9132ca29c723bdf037f1a891a70c"
+                + "&fromBlock=379224"
+                + "&toBlock=400000"
+                + "&topic0=0xf63780e752c6a54a94fc52715dbc5518a3b4c3c2833d301a204226548a2a8545"
+                + "&topic1=0x72657075746174696f6e00000000000000000000000000000000000000000000"
+                + "&topic3=0x00000000000000000000000013990122638b9132ca29c723bdf037f1a891a70c"
+                + "&topic0_1_opr=and"
+                + "&topic0_3_opr=or"
+                + "&topic1_3_opr=or", triple.getParams());
     }
 
-    @Test(expected = LogQueryException.class)
-    public void quadroInCorrectOp5() {
-        LogTopicQuadro topicQuadro = LogQueryBuilder.with("0x33990122638b9132ca29c723bdf037f1a891a70c")
-                .topic("0xf63780e752c6a54a94fc52715dbc5518a3b4c3c2833d301a204226548a2a8545",
-                        "0x72657075746174696f6e00000000000000000000000000000000000000000000",
-                        "0xf63780e752c6a54a94fc52715dbc5518a3b4c3c2833d301a204226548a2a8545",
-                        "0xf63780e752c6a54a94fc52715dbc5518a3b4c3c2833d301a204226548a2a8545");
-
-        topicQuadro
-                .setOpTopic0_1(LogOp.AND)
-                .setOpTopic0_2(LogOp.OR)
-                .setOpTopic0_3(LogOp.AND)
-                .setOpTopic1_2(LogOp.AND)
-                .setOpTopic1_3(null)
-                .setOpTopic2_3(LogOp.OR)
+    @Test
+    public void triple_zeroTwoThree() {
+        LogQuery triple = LogQueryBuilder.with("0x33990122638b9132ca29c723bdf037f1a891a70c", 379224, 400000)
+                .topic(TopicParamsFactory.of(
+                        createTopicZero("0xf63780e752c6a54a94fc52715dbc5518a3b4c3c2833d301a204226548a2a8545"),
+                        createTopicTwo("0x72657075746174696f6e00000000000000000000000000000000000000000000"),
+                        createTopicThree("0x00000000000000000000000013990122638b9132ca29c723bdf037f1a891a70c"),
+                        new LogOperatorZeroTwo(LogOp.AND),
+                        new LogOperatorZeroThree(LogOp.OR),
+                        new LogOperatorTwoThree(LogOp.OR)))
                 .build();
+
+        assertNotNull(triple);
+        assertNotNull(triple.getParams());
+        assertEquals("&address=0x33990122638b9132ca29c723bdf037f1a891a70c"
+                + "&fromBlock=379224"
+                + "&toBlock=400000"
+                + "&topic0=0xf63780e752c6a54a94fc52715dbc5518a3b4c3c2833d301a204226548a2a8545"
+                + "&topic2=0x72657075746174696f6e00000000000000000000000000000000000000000000"
+                + "&topic3=0x00000000000000000000000013990122638b9132ca29c723bdf037f1a891a70c"
+                + "&topic0_2_opr=and"
+                + "&topic0_3_opr=or"
+                + "&topic2_3_opr=or", triple.getParams());
     }
 
-    @Test(expected = LogQueryException.class)
-    public void quadroInCorrectOp6() {
-        LogTopicQuadro topicQuadro = LogQueryBuilder.with("0x33990122638b9132ca29c723bdf037f1a891a70c")
-                .topic("0xf63780e752c6a54a94fc52715dbc5518a3b4c3c2833d301a204226548a2a8545",
-                        "0x72657075746174696f6e00000000000000000000000000000000000000000000",
-                        "0xf63780e752c6a54a94fc52715dbc5518a3b4c3c2833d301a204226548a2a8545",
-                        "0xf63780e752c6a54a94fc52715dbc5518a3b4c3c2833d301a204226548a2a8545");
-
-        topicQuadro
-                .setOpTopic0_1(LogOp.AND)
-                .setOpTopic0_2(LogOp.OR)
-                .setOpTopic0_3(LogOp.AND)
-                .setOpTopic1_2(LogOp.AND)
-                .setOpTopic1_3(LogOp.OR)
-                .setOpTopic2_3(null)
+    @Test
+    public void triple_oneTwoThree() {
+        LogQuery triple = LogQueryBuilder.with("0x33990122638b9132ca29c723bdf037f1a891a70c", 379224, 400000)
+                .topic(TopicParamsFactory.of(
+                        createTopicOne("0xf63780e752c6a54a94fc52715dbc5518a3b4c3c2833d301a204226548a2a8545"),
+                        createTopicTwo("0x72657075746174696f6e00000000000000000000000000000000000000000000"),
+                        createTopicThree("0x00000000000000000000000013990122638b9132ca29c723bdf037f1a891a70c"),
+                        new LogOperatorOneTwo(LogOp.AND),
+                        new LogOperatorOneThree(LogOp.OR),
+                        new LogOperatorTwoThree(LogOp.OR)))
                 .build();
+
+        assertNotNull(triple);
+        assertNotNull(triple.getParams());
+        assertEquals("&address=0x33990122638b9132ca29c723bdf037f1a891a70c"
+                + "&fromBlock=379224"
+                + "&toBlock=400000"
+                + "&topic1=0xf63780e752c6a54a94fc52715dbc5518a3b4c3c2833d301a204226548a2a8545"
+                + "&topic2=0x72657075746174696f6e00000000000000000000000000000000000000000000"
+                + "&topic3=0x00000000000000000000000013990122638b9132ca29c723bdf037f1a891a70c"
+                + "&topic1_2_opr=and"
+                + "&topic1_3_opr=or"
+                + "&topic2_3_opr=or", triple.getParams());
     }
 
-    @Test(expected = LogQueryException.class)
-    public void quadroInCorrectTopic() {
-        LogQuery quadro = LogQueryBuilder.with("0x33990122638b9132ca29c723bdf037f1a891a70c")
-                .topic("0xf63780e752c6a54a94fc52715dbc5518a3b4c3c2833d301a204226548a2a8545",
-                        "0x72657075746174696f6e00000000000000000000000000000000000000000000",
-                        "",
-                        "")
-                .setOpTopic0_1(LogOp.AND)
-                .setOpTopic0_2(LogOp.OR)
-                .setOpTopic0_3(LogOp.AND)
-                .setOpTopic1_2(LogOp.OR)
-                .setOpTopic1_3(LogOp.OR)
-                .setOpTopic2_3(LogOp.OR)
+    @Test
+    public void quadruple() {
+        LogQuery quadruple = LogQueryBuilder.with("0x33990122638b9132ca29c723bdf037f1a891a70c", 379224, 400000)
+                .topic(TopicParamsFactory.of(
+                        createTopicZero("0x0000000000000000000000001d4426f94e42f721C7116E81d6688cd935cB3b4F"),
+                        createTopicOne("0xf63780e752c6a54a94fc52715dbc5518a3b4c3c2833d301a204226548a2a8545"),
+                        createTopicTwo("0x72657075746174696f6e00000000000000000000000000000000000000000000"),
+                        createTopicThree("0x00000000000000000000000013990122638b9132ca29c723bdf037f1a891a70c"),
+                        new LogOperatorZeroOne(LogOp.OR),
+                        new LogOperatorZeroTwo(LogOp.AND),
+                        new LogOperatorZeroThree(LogOp.OR),
+                        new LogOperatorOneTwo(LogOp.AND),
+                        new LogOperatorOneThree(LogOp.OR),
+                        new LogOperatorTwoThree(LogOp.OR)))
                 .build();
 
-        assertNotNull(quadro);
-        assertNotNull(quadro.getParams());
+        assertNotNull(quadruple);
+        assertNotNull(quadruple.getParams());
+        assertEquals("&address=0x33990122638b9132ca29c723bdf037f1a891a70c"
+                + "&fromBlock=379224"
+                + "&toBlock=400000"
+                + "&topic0=0x0000000000000000000000001d4426f94e42f721C7116E81d6688cd935cB3b4F"
+                + "&topic1=0xf63780e752c6a54a94fc52715dbc5518a3b4c3c2833d301a204226548a2a8545"
+                + "&topic2=0x72657075746174696f6e00000000000000000000000000000000000000000000"
+                + "&topic3=0x00000000000000000000000013990122638b9132ca29c723bdf037f1a891a70c"
+                + "&topic0_1_opr=or"
+                + "&topic0_2_opr=and"
+                + "&topic0_3_opr=or"
+                + "&topic1_2_opr=and"
+                + "&topic1_3_opr=or"
+                + "&topic2_3_opr=or", quadruple.getParams());
+    }
+
+    private TopicZero createTopicZero(String hex) {
+        return new TopicZero(LogTopic.of(hex));
+    }
+
+    private TopicOne createTopicOne(String hex) {
+        return new TopicOne(LogTopic.of(hex));
+    }
+
+    private TopicTwo createTopicTwo(String hex) {
+        return new TopicTwo(LogTopic.of(hex));
+    }
+
+    private TopicThree createTopicThree(String hex) {
+        return new TopicThree(LogTopic.of(hex));
     }
 }

--- a/src/test/java/io/api/etherscan/model/AddressTest.java
+++ b/src/test/java/io/api/etherscan/model/AddressTest.java
@@ -1,0 +1,29 @@
+package io.api.etherscan.model;
+
+import io.api.etherscan.error.InvalidAddressException;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class AddressTest extends Assert {
+
+    @Test(expected = InvalidAddressException.class)
+    public void invalidAddress() {
+        Address.of("033990122638b9132ca29c723bdf037f1a891a70c");
+    }
+
+    @Test
+    public void validAddress() {
+        Address address = Address.of("0x33990122638b9132ca29c723bdf037f1a891a70c");
+        assertEquals("0x33990122638b9132ca29c723bdf037f1a891a70c", address.getAddress());
+
+        Address sameAddress = Address.of("0x33990122638b9132ca29c723bdf037f1a891a70c");
+        assertEquals(address, sameAddress);
+        assertEquals(address.hashCode(), sameAddress.hashCode());
+    }
+
+    @Test
+    public void to64Hex() {
+        Address address = Address.of("0x33990122638b9132ca29c723bdf037f1a891a70c");
+        assertEquals("0x00000000000000000000000033990122638b9132ca29c723bdf037f1a891a70c", address.to64Hex());
+    }
+}

--- a/src/test/java/io/api/etherscan/model/query/LogTopicTest.java
+++ b/src/test/java/io/api/etherscan/model/query/LogTopicTest.java
@@ -1,0 +1,32 @@
+package io.api.etherscan.model.query;
+
+import io.api.etherscan.error.InvalidTxHashException;
+import io.api.etherscan.model.Address;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class LogTopicTest extends Assert {
+
+    @Test
+    public void fromAddress() {
+        Address address = Address.of("0x33990122638b9132ca29c723bdf037f1a891a70c");
+        LogTopic logTopic = LogTopic.of(address);
+
+        assertEquals("0x00000000000000000000000033990122638b9132ca29c723bdf037f1a891a70c", logTopic.getHex());
+    }
+
+    @Test(expected = InvalidTxHashException.class)
+    public void invalid() {
+        LogTopic.of("ddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef");
+    }
+
+    @Test
+    public void valid() {
+        LogTopic logTopic = LogTopic.of("0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef");
+        assertEquals("0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef", logTopic.getHex());
+
+        LogTopic sameLogTopic = LogTopic.of("0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef");
+        assertEquals(logTopic, sameLogTopic);
+        assertEquals(logTopic.hashCode(), sameLogTopic.hashCode());
+    }
+}


### PR DESCRIPTION
With the emergence of side chains and layer 2s, etherscan expanded its offerings and supports block explorer APIs for other networks as well. Since the API requests and responses are fairly similar between the networks, the extension should not be too difficult.

### Changes
I created a BaseApi class for the setup and a Network interface to get the correct API-URL. I added the Polygonscan implementation as the first alternative API. I left the EthNetwork enum in the module as before, but I think it might be better to place it in the network submodule.

### Todos
Since some requests and responses are different between Polygonscan and Etherscan (especially for the stats APIs), more specifications regarding the setup of the specific endpoints might be required (e.g. protected initialization methods for endpoint APIs with default implementation such as IStatisticApi createStatisticsApi() { return new PolygonStatisticsApi()}). 

### Testing
I added some basic account and contract api tests with random addresses. I am not sure how to best integrate specific endpoint api tests into the current testing architecture. Do you have any suggestions?

Looking forward to your thoughts and ideas. 